### PR TITLE
CBR2-2197 : xdns multiprofile flag missing in /etc/resolv.conf

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_deviceinfo_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_deviceinfo_apis.c
@@ -5476,8 +5476,8 @@ int setMultiProfileXdnsConfig(BOOL bValue)
                         fprintf(fp1, "%s", confEntry);
                 }
 
-                //copy only dnsoverride entries and Multi_profile into nvram
-                if (strstr(confEntry, "dnsoverride") || strstr(confEntry, "XDNS_Multi_Profile"))
+                //copy only dnsoverride entries into nvram
+                if (strstr(confEntry, "dnsoverride"))
                 {
 
                         fprintf(fp2, "%s", confEntry);


### PR DESCRIPTION
Reason for change: Populate XDNS_Multi_Profile entry in resolv.conf
                   based on syscfg key MultiProfileXDNS instead of
                   maintaining the config in /nvram/dnsmasq_servers.conf
Test Procedure:
1) 'XDNS_Multi_Profile Enabled' entry will be present in resolv.conf
   if XDNS is enabled and MultiProfile RFC is set to true.
2) 'XDNS_Multi_Profile Disabled' entry will be present in resolv.conf
   if XDNS is enabled and MultiProfile RFC is set to true.
3) XDNS_Multi_Profile entry will be absent in resolv.conf if XDNS is
   disabled.

Change-Id: I14dbdd4ce2c6d636c87b70383d16253500dc9242 Risks: Low
Priority: P1
Signed-off-by: Santhosh_GujulvaJagadeesh@comcast.com (cherry picked from commit da853e4eb7dba03c69504d4289e1947b830d6e24)