### PR TITLE
RDKCOM-5368: RDKBDEV-3218 : Fix 64-bit sprintf() formatting issues in…

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
@@ -10655,7 +10655,7 @@ dhcpv6c_dbg_thrd(void * in)
                             if (strlen(globalIP2) != 0 )
                             {
                                 g_dhcpv6s_refresh_count = bRestartLan;
-                                CcspTraceWarning(("%s: g_dhcpv6s_refresh_count %ld, globalIP2 is %s, strlen is %d\n", __func__, g_dhcpv6s_refresh_count,globalIP2,strlen(globalIP2)));
+                                CcspTraceWarning(("%s: g_dhcpv6s_refresh_count %ld, globalIP2 is %s, strlen is %zu\n", __func__, g_dhcpv6s_refresh_count,globalIP2,strlen(globalIP2)));
 
                             }
                             rc = strcpy_s(globalIP2, sizeof(globalIP2), globalIP);


### PR DESCRIPTION
… PandM

Reason for change: 64-bit sprintf() formatting issue were observed in ccsp-p-and-m code.This will be fixed here.
Risks: Low
Signed-off-by: Aiswarya Prasad <aprasad@maxlinear.com>
Test Procedure: None.
Priority: P1

Change-Id: I2ba5d358bc106f6561c78f272a4ca04c06e27c23 (cherry picked from commit adec6b244294f015368f31dca57a61c8f1dbba61)