### PR TITLE
CBR2-2194 : Wifi Values not applied

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
@@ -1645,7 +1645,7 @@ CosaDmlDcSetRebootDevice
 		}
 		else
         {
-#if defined (_CBR_PRODUCT_REQ_) || defined (_BWG_PRODUCT_REQ_)
+#if defined (_CBR_PRODUCT_REQ_) || defined (_BWG_PRODUCT_REQ_) || defined (_CBR2_PRODUCT_REQ_)
 //TCCBR-4087
             int                         ret = -1;
             int                         size = 0;
@@ -1671,11 +1671,8 @@ CosaDmlDcSetRebootDevice
 
             if ( ret == CCSP_SUCCESS && size == 1)
             {
-
-                parameterValStruct_t val[ ] = { { "Device.WiFi.Radio.1.X_CISCO_COM_ApplySetting", "true", ccsp_boolean},
-			{ "Device.WiFi.Radio.1.X_CISCO_COM_ApplySettingSSID", "1", ccsp_int},
-			{ "Device.WiFi.Radio.2.X_CISCO_COM_ApplySetting", "true", ccsp_boolean},
-			{ "Device.WiFi.Radio.2.X_CISCO_COM_ApplySettingSSID", "1", ccsp_int} };
+                parameterValStruct_t val[ ] = { { "Device.WiFi.ApplyAccessPointSettings", "true", ccsp_boolean},
+			{ "Device.WiFi.ApplyRadioSettings", "true", ccsp_boolean}};
 
                 ret = CcspBaseIf_setParameterValues
                     (


### PR DESCRIPTION
Reason for change: wifi configurations were not applied in save and restore.
Test Procedure: After restoring check if wifi configs are changed.

Change-Id: I671c1530b9d31bc193d5c794d87046e0848b193a Risks: Medium
Priority: P0
Signed-off-by: GuruChandru_Saravanan@comcast.com
(cherry picked from commit d84215b6a9e610e920212d4a4ef638fd112759fb)