### PR TITLE
RDKB-55780: IP address & subnet is not reflecting correctly in UI

### DIFF
--- a/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c
@@ -1964,6 +1964,9 @@ LanMngm_GetParamUlongValue
     PCOSA_CONTEXT_LINK_OBJECT       pLinkObj    = (PCOSA_CONTEXT_LINK_OBJECT)hInsContext;
     PCOSA_DML_LAN_MANAGEMENT        pLanMngm    = (PCOSA_DML_LAN_MANAGEMENT)pLinkObj->hContext;
 
+    char ip_buff[16]  = {0};
+    struct in_addr addr;
+
     if (strcmp(ParamName, "LanMode") == 0)
     {
         *pUlong = pLanMngm->LanMode;
@@ -1981,12 +1984,22 @@ LanMngm_GetParamUlongValue
     }
     if (strcmp(ParamName, "LanSubnetMask") == 0)
     {
-        *pUlong = pLanMngm->LanSubnetMask.Value;
+        syscfg_get(NULL, DHCPV4_LAN_NETMASK , ip_buff, sizeof(ip_buff));
+        if (inet_pton(AF_INET, ip_buff, &addr) != 1) {
+            CcspTraceWarning(("inet_pton: Invalid IPv4 address\n"));
+            return FALSE;
+        }
+        *pUlong = addr.s_addr;
         return TRUE;
     }
     if (strcmp(ParamName, "LanIPAddress") == 0)
     {
-        *pUlong = pLanMngm->LanIPAddress.Value;
+        syscfg_get(NULL, DHCPV4_LAN_IP, ip_buff, sizeof(ip_buff));
+        if (inet_pton(AF_INET, ip_buff, &addr) != 1) {
+            CcspTraceWarning(("inet_pton: Invalid IPv4 address\n"));
+            return FALSE;
+        }
+        *pUlong = addr.s_addr;
         return TRUE;
     }
     if (strcmp(ParamName, "LanTos") == 0)
@@ -2101,6 +2114,9 @@ LanMngm_SetParamUlongValue
     BOOL                                      bridgeMode;
     ULONG                                     deviceMode;
 
+    char ip_buff[16]  = {0};
+    struct in_addr addr;
+
     if (CosaDmlDcGetDeviceMode(NULL, &deviceMode) != ANSC_STATUS_SUCCESS)
             return FALSE;
     
@@ -2163,6 +2179,11 @@ LanMngm_SetParamUlongValue
     }
     if (strcmp(ParamName, "LanSubnetMask") == 0)
     {
+        addr.s_addr = uValuepUlong;
+        if (inet_ntop(AF_INET, &addr, ip_buff, sizeof(ip_buff)) == NULL) {
+            CcspTraceWarning(("inet_ntop: Invalid IPv4 address\n"));
+            return FALSE;
+        }
         if (Dhcpv4_Lan_MutexTryLock() != 0)
         {
             CcspTraceWarning(("%s not supported if already lan blob update is inprogress\n",ParamName));
@@ -2170,6 +2191,7 @@ LanMngm_SetParamUlongValue
         }
 
 		CcspTraceWarning(("RDKB_LAN_CONFIG_CHANGED: Setting new LanSubnetMask value  ...\n"));
+        syscfg_set_commit(NULL, DHCPV4_LAN_NETMASK, ip_buff);
         pLanMngm->LanSubnetMask.Value = uValuepUlong;
         lan_ip_config_modified=true;
         Dhcpv4_Lan_MutexUnLock();
@@ -2177,6 +2199,11 @@ LanMngm_SetParamUlongValue
     }
     if (strcmp(ParamName, "LanIPAddress") == 0)
     {
+        addr.s_addr = uValuepUlong;
+        if (inet_ntop(AF_INET, &addr, ip_buff, sizeof(ip_buff)) == NULL) {
+            CcspTraceWarning(("inet_ntop: Invalid IPv4 address\n"));
+            return FALSE;
+        }
         if (Dhcpv4_Lan_MutexTryLock() != 0)
         {
             CcspTraceWarning(("%s not supported if already lan blob update is inprogress\n",ParamName));
@@ -2184,6 +2211,7 @@ LanMngm_SetParamUlongValue
         }
 
 		CcspTraceWarning(("RDKB_LAN_CONFIG_CHANGED: Setting new LanIPAddress value  ...\n"));
+        syscfg_set_commit(NULL, DHCPV4_LAN_IP, ip_buff);
         pLanMngm->LanIPAddress.Value = uValuepUlong;
         lan_ip_config_modified=true;
         Dhcpv4_Lan_MutexUnLock();


### PR DESCRIPTION
Reason for change: Through lan blob or tr181 when try to set GW IP address & subnet is not reflecting correctly in UI Test Procedure: Change GW IP address, subnet mask, lease time, min & max address through lan blob. Risks: Low
Priority: P1
Signed-off-by:Veeraputhiran_Thangavel@comcast.com

Change-Id: I3a0306c3045bd653249aff014535f64bda087760 (cherry picked from commit ac183323e2ae078865d5b147a84b510c8613e78a) (cherry picked from commit 3cd34cea37345fe60a2ff1d1f465fc738fbe8c17)