### PR TITLE
RDKB-59933: Observed RDKB_PROCESS_CRASHED : Dibbler is not running

### DIFF
--- a/arch/intel_usg/boards/arm_shared/scripts/network_response.sh
+++ b/arch/intel_usg/boards/arm_shared/scripts/network_response.sh
@@ -315,7 +315,7 @@ restartLanServices()
     # Modify DNS server option in dibbler configuration
     if [ -e $SERVER6_CONF ]
     then
-	Uncommented_line=`cat $SERVER6_CONF | grep dns-server | sed -e 's/.//'`
+	Uncommented_line=`cat $SERVER6_CONF | grep dns-server | sed -e 's/^#//'`
 	#cat $SERVER6_CONF | grep dns-server | sed -e 's/.//' > $SERVER6_BKUP
 	sed "/dns-server/c \
 	\ \ \ \ $Uncommented_line"  $SERVER6_CONF > $SERVER6_BKUP

--- a/arch/intel_usg/boards/arm_shared/scripts/restart_services.sh
+++ b/arch/intel_usg/boards/arm_shared/scripts/restart_services.sh
@@ -39,7 +39,7 @@ then
 	then
 		sed -e '/dns-server/s/^/#/g' -i $SERVER6_CONF 
 	else
-		Uncommented_line=`cat $SERVER6_CONF | grep dns-server | sed -e 's/.//'`
+		Uncommented_line=`cat $SERVER6_CONF | grep dns-server | sed -e 's/^#//'`
 		#cat $SERVER6_CONF | grep dns-server | sed -e 's/.//' > $SERVER6_BKUP
 		sed "/dns-server/c \
 		\ \ \ \ $Uncommented_line"  $SERVER6_CONF > $SERVER6_BKUP


### PR DESCRIPTION
Reason for change: Dibbler is not running, restarting the dibbler after factory reset

Test Procedure: Build and verify
Risks: Low
Priority: P2

Change-Id: I3ce0f4fe6a941cef7bc6eafe007d0fd973eaa979

(cherry picked from commit 517a46341eb6d09c4f6a9e8c233ba0e4bc939a01)