### PR TITLE
RDKCOM-5342: RDKBDEV-3196, RDKBACCL-644 : Observing Product Type is XB3 in C

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_deviceinfo_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_deviceinfo_apis.c
@@ -703,7 +703,7 @@ CosaDmlDiGetProductClass
                     return ANSC_STATUS_FAILURE;
                 }
         }
-#elif defined(_PLATFORM_RASPBERRYPI_)
+#elif defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_BANANAPI_R4_)
         {
                 rc = strcpy_s(pValue, *pulSize, "ER");
                 if ( rc != EOK) {


### PR DESCRIPTION
Reason for change: In BPI R4, Product Type is showing as XB3, modified to ER
Test Procedure: dmcli eRT getv Device.DeviceInfo.ProductClass
Risks: Low
Signed-off-by: ssiras826 <ssiras826@cable.comcast.com>
Priority: P1

Change-Id: Icd8bae060842c92fd4387b062b48723b7766baf2 (cherry picked from commit 2b0af383a40cd09289d50e16d40a8d47f02aa797)