### PR TITLE
Revert "XB10-1658: Local build only PandM not operational."

### DIFF
--- a/source-arm/TR-181/board_sbapi/Makefile.am
+++ b/source-arm/TR-181/board_sbapi/Makefile.am
@@ -114,7 +114,7 @@ if CORE_NET_LIB_FEATURE_SUPPORT
 libCcspPandM_board_sbapi_la_LDFLAGS += -lnet
 endif
 
-libCcspPandM_board_sbapi_la_LDFLAGS = -lccsp_common -ltime_conversion -lwebconfig_framework -lmsgpackc -lrdkconfig
+libCcspPandM_board_sbapi_la_LDFLAGS = -lccsp_common -ltime_conversion -lwebconfig_framework -lmsgpackc
 if FEATURE_HOTSPOT_SUPPORT
 libCcspPandM_board_sbapi_la_LDFLAGS += -lHotspotApi
 endif


### PR DESCRIPTION
Reason for Revert - RDKB-59915

This reverts commit 9d8ba56ff6bb88f372f57d619369139fbefab7dd.

Change-Id: I03d5d63a4486add4ff5ff2f6755a52378f70d434 (cherry picked from commit cb83c7248d7291e1a22d55592d8c78962de0ac07)