### PR TITLE
RDKB-60892 : Mgmt ui port overlaps with PF or PT port

### DIFF
--- a/source/TR-181/include/cosa_nat_apis.h
+++ b/source/TR-181/include/cosa_nat_apis.h
@@ -393,6 +393,8 @@ CosaDmlNatChkPortMappingMaxRuleNum(PCOSA_DML_NAT_PMAPPING pEntry);
 
 void CosaDmlNatDelDynPortMappings (void);
 
+int IsPortOverlapWithManagementAccess(int PortStart, int PortEndRange);
+
 #if defined (SPEED_BOOST_SUPPORTED)
 int
 IsPortOverlapWithSpeedboostPortRange(int ExternalPort, int ExternalPortEndRange, int InternalPort , int InternalPortend);

--- a/source/TR-181/include/cosa_x_cisco_com_devicecontrol_apis.h
+++ b/source/TR-181/include/cosa_x_cisco_com_devicecontrol_apis.h
@@ -909,6 +909,9 @@ IsPortInUse
 (
     unsigned int port
 );
+bool IsPortOverlapWithPFPorts(int mgmtport);
+bool IsPortOverlapWithPTPorts(int mgmtport);
+
 
 ANSC_STATUS
 CosaDmlDcSetReinitMacThreshold

--- a/source/TR-181/middle_layer_src/cosa_webconfig_api.c
+++ b/source/TR-181/middle_layer_src/cosa_webconfig_api.c
@@ -479,6 +479,11 @@ int set_portmap_conf(portmappingdoc_t *rpm)
                 return INVALID_PORT ;
             }
 
+            if( IsPortOverlapWithManagementAccess(atoi(rpm->entries[j].external_port), atoi(rpm->entries[j].external_port_end_range)))
+            {
+                CcspTraceError(("%s: Port Range %d - %d is overlapping with Management Access port \n",__FUNCTION__,atoi(rpm->entries[j].external_port), atoi(rpm->entries[j].external_port_end_range)));
+                return INVALID_PORT ;
+            }
 
 #if defined (SPEED_BOOST_SUPPORTED)
             if( IsPortOverlapWithSpeedboostPortRange(atoi(rpm->entries[j].external_port), atoi(rpm->entries[j].external_port_end_range) , 0, 0))

--- a/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c
@@ -1286,7 +1286,12 @@ X_CISCO_COM_DeviceControl_SetParamUlongValue
             CcspTraceWarning(("Port already in use\n"));
             return FALSE;
         }
-        if((uValue >= START_HTTPPORT) && (uValue <= END_HTTPPORT))
+
+	//check if the http port is overlap with PT or PF
+        if (IsPortOverlapWithPFPorts(uValue) || IsPortOverlapWithPTPorts(uValue))
+            return FALSE;
+
+	if((uValue >= START_HTTPPORT) && (uValue <= END_HTTPPORT))
         {
             pMyObject->HTTPPort = uValue;
             pMyObject->WebServerChanged = TRUE;
@@ -1303,6 +1308,11 @@ X_CISCO_COM_DeviceControl_SetParamUlongValue
             CcspTraceWarning(("Port already in use\n"));
             return FALSE;
         }
+
+	//check if the https port is overlap with PT or PF
+        if (IsPortOverlapWithPFPorts(uValue) || IsPortOverlapWithPTPorts(uValue))
+            return FALSE;
+
         if((uValue >= START_HTTPPORT) && (uValue <= END_HTTPPORT))
         {
             pMyObject->HTTPSPort = uValue;


### PR DESCRIPTION
Reason for change: Ensuring remote management UI port does not uses already configured Port forward or Port trigger ports and vice versa. 
Test Procedure: 1) Ensure remotes management UI http or https port does not uses already configured port forward or port trigger ports. 2) Ensure port forward or port trigger ports does not uses already configured http or https ports.
3) check PF , PT functionality works on the configured ports. 4) Check webui is accessible on the user configured http , https ports. 
Risks: Low
Priority: P1
Signed-off-by: vijayaragavalu_sundaresan2@comcast.com

Change-Id: Ic67062f30eb11bae5f5d1ddd4971efb7f0482d76