### PR TITLE
XHCPE-2145: Add DeviceNim RFC flag to control Matter and Thread

### DIFF
--- a/config-arm/TR181-USGv2.XML
+++ b/config-arm/TR181-USGv2.XML
@@ -3918,6 +3918,22 @@
                                 </parameter>
                             </parameters>
                         </object>
+                        <object>
+                            <name>NIM</name>
+                            <objectType>object</objectType>
+                            <functions>
+                                <func_GetParamBoolValue>NIM_GetParamBoolValue</func_GetParamBoolValue>
+                                <func_SetParamBoolValue>NIM_SetParamBoolValue</func_SetParamBoolValue>
+                            </functions>
+                            <parameters>
+                                <parameter>
+                                    <name>Enable</name>
+                                    <type>boolean</type>
+                                    <syntax>bool</syntax>
+                                    <writable>true</writable>
+                                </parameter>
+                            </parameters>
+                        </object>
 <?endif?>
 <?ifdef FEATURE_RDKB_NFC_MANAGER?>
                         <object>

--- a/config-arm/TR181-USGv2_bci.XML
+++ b/config-arm/TR181-USGv2_bci.XML
@@ -2354,6 +2354,22 @@
                                 </parameter>
                             </parameters>
                         </object>
+                        <object>
+                           <name>NIM</name>
+                           <objectType>object</objectType>
+                           <functions>
+                              <func_GetParamBoolValue>NIM_GetParamBoolValue</func_GetParamBoolValue>
+                              <func_SetParamBoolValue>NIM_SetParamBoolValue</func_SetParamBoolValue>
+                           </functions>
+                           <parameters>
+                              <parameter>
+                                 <name>Enable</name>
+                                 <type>boolean</type>
+                                 <syntax>bool</syntax>
+                                 <writable>true</writable>
+                              </parameter>
+                           </parameters>
+                        </object>
                 </objects>
 		</object>
 		</objects>

--- a/config-arm/TR181-USGv2_nowifi.XML
+++ b/config-arm/TR181-USGv2_nowifi.XML
@@ -3736,6 +3736,22 @@
                                 </parameter>
                             </parameters>
                         </object>
+                        <object>
+                            <name>NIM</name>
+                            <objectType>object</objectType>
+                            <functions>
+                                <func_GetParamBoolValue>NIM_GetParamBoolValue</func_GetParamBoolValue>
+                                <func_SetParamBoolValue>NIM_SetParamBoolValue</func_SetParamBoolValue>
+                            </functions>
+                            <parameters>
+                                <parameter>
+                                    <name>Enable</name>
+                                    <type>boolean</type>
+                                    <syntax>bool</syntax>
+                                    <writable>true</writable>
+                                </parameter>
+                            </parameters>
+                        </object>
 <?endif?>
 <?ifdef FEATURE_RDKB_NFC_MANAGER?>
                         <object>

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -23001,6 +23001,124 @@ XHFW_SetParamBoolValue (ANSC_HANDLE hInsContext, char* ParamName, BOOL bValue)
     }
     return result;
 }
+
+/**
+ *  RFC Feature NIM
+*/
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        device.nim_GetParamBoolValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                BOOL*                       pBool
+            );
+
+    description:
+
+        This function is called to retrieve Boolean parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                BOOL*                       pBool
+                The buffer of returned boolean value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
+
+BOOL
+NIM_GetParamBoolValue ( ANSC_HANDLE hInsContext, char* ParamName, BOOL* pBool)
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+    if (strcmp(ParamName, "Enable") == 0)
+    {
+        char value[8] = {'\0'};
+        if( syscfg_get(NULL, "NIM_Enable", value, sizeof(value)) == 0 )
+        {
+            /* CID: 155008 Array name value  compared against 0*/
+            *pBool = (strcmp(value, "true") == 0) ? TRUE : FALSE;
+            return TRUE;
+        }
+        else
+        {
+            CcspTraceError(("syscfg_get failed for NIM_Enable\n"));
+        }
+    }
+    return FALSE;
+}
+
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        NIM_SetParamBoolValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                BOOL                        bValue
+            );
+
+    description:
+
+        This function is called to set BOOL parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                BOOL                        bValue
+                The updated BOOL value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
+
+BOOL
+NIM_SetParamBoolValue (ANSC_HANDLE hInsContext, char* ParamName, BOOL bValue)
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+    BOOL result = FALSE;
+
+    if (strcmp(ParamName, "Enable") == 0)
+    {
+        if (syscfg_set_commit(NULL, "NIM_Enable", bValue ? "true" : "false") != 0)
+        {
+            CcspTraceError(("syscfg_set failed for NIM_Enable\n"));
+        }
+        else
+        {
+            result = TRUE;
+        }
+
+        if (bValue)
+        {
+            v_secure_system("systemctl restart zilker");
+            v_secure_system("systemctl reset-failed otbr-agent.path otbr-agent");
+            v_secure_system("systemctl restart otbr-agent");
+        }
+        else
+        {
+            v_secure_system("systemctl stop otbr-agent");
+            v_secure_system("systemctl restart zilker");
+        }
+    }
+    return result;
+}
 #endif
 
 static void Replace_AllOccurrence(char *str, int size, char ch, char Newch)


### PR DESCRIPTION
Reason for change: This update introduces a new RFC feature flag named "NIM", which controls the operation of the otbr-agent service and and restarts Zilker, which internally monitor this flag and respond accordingly.

Risks: None

Test Procedure: Set Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.NIM.Enable to true/false to verify behavior.