### PR TITLE
RDKB-61239 : No internet connectivity after firewall FR

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
@@ -2312,6 +2312,10 @@ CosaDmlDcSetFactoryReset
             CcspTraceWarning(("X_CISCO_SECURITY: Error in initializing context!!! \n" ));
             return ANSC_STATUS_FAILURE;
         }
+        fw.allow_ipsec_passthru = 1;
+        fw.allow_pptp_passthru = 1;
+        fw.allow_l2tp_passthru = 1;
+        fw.allow_ssl_passthru = 1;
         fw.filter_ident = 0;
         fw.filter_multicast = 0;
         fw.filter_anon_req = 0;


### PR DESCRIPTION
Reason for change: initialized the VPN passthrough with default value as ACCEPT 
when factory reset is called with firewall option
Test Procedure: Factory Reset with various option including firewall and 
VPN Passthrough get and set and then test the functionality 
Risks: Medium
Priority: P1
Signed-off-by: vijayaragavalu_sundaresan2@comcast.com

Change-Id: I77042d6f2d597c41306e5679242ce80f515a9fd0