### PR TITLE
RDKB-57735 : Refactoring of sync notification

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_common_util.h
+++ b/source-arm/TR-181/board_sbapi/cosa_common_util.h
@@ -70,13 +70,18 @@
 #include "dmsb_tr181_psm_definitions.h"
 
 #define MAX_EVENT_NAME_LENGTH   32
+#define WEBPA_NOTIFY_QUEUE "/sync_notify_queue"
+#define MAX_QUEUE_SIZE 100
+#define MAX_MSG_SIZE sizeof(arg_struct_t)
+#define PARAM_NAME_LEN 128
+#define VALUE_LEN      128
 
 #if defined (RBUS_WAN_IP)
 typedef struct{
-    char* parameterName;
+    char parameterName[PARAM_NAME_LEN];
     unsigned int writeID;
-    char* newValue;
-    char* oldValue;
+    char newValue[VALUE_LEN];
+    char oldValue[VALUE_LEN];
     enum dataType_e type;
 }arg_struct_t;
 #endif /*RBUS_WAN_IP*/
@@ -193,3 +198,6 @@ void free_args_struct(arg_struct_t *param);
 unsigned char IsThisCurrentPartnerID( const char* pcPartnerID );
 unsigned char IsThisFeatureApplicable( const char* pcFeatureFlag, common_util_InputSourceType  enInputSourceType );
 #endif
+
+void initializeNotificationHandler(void);
+

--- a/source/TR-181/middle_layer_src/plugin_main_apis.c
+++ b/source/TR-181/middle_layer_src/plugin_main_apis.c
@@ -349,6 +349,10 @@ CosaBackEndManagerInitialize
     pMyObject->hInterfaceStack = (ANSC_HANDLE)CosaIFStackCreate();
     AnscTraceWarning(("  CosaIFStackCreate done!\n"));
 #endif
+
+    // initiatlize the thread to send sync notifcation to webPA when IPv6 prefix , IPV4 and IPv6 ip address change
+    initializeNotificationHandler();
+
 #ifndef FEATURE_RDKB_XDSL_PPP_MANAGER
 #if !defined (RESOURCE_OPTIMIZATION)
     pMyObject->hPPP           = (ANSC_HANDLE)CosaPPPCreate();


### PR DESCRIPTION
Reason for change: created new message queue as part of merging the ipv6 prefix and ip addr threads and added same queue name into apparmor for the accessing in CcspPandM component.
Test Procedure: 1) check CcspPandM up and running
2) check webPA receives the notification for first time ip addr assign and new change events
3) Remove and reinsert the wan feed and confirm sync notifications are posted 4) Reboot multiple times and check no spike in the boot up 5) change the prefix on multiple scenarios and check sync notifcations are ported 
Risks: MEDIUM
Priority: P1
Signed-off-by: vijayaragavalu_sundaresan2@comcast.com

Change-Id: I579a3a01864b2ddb7818e2ac0964271392695441