### PR TITLE
RDKCOM-5442: RDKBDEV-3232 drop obsolete code conditional on ARRIS_XB3…

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_ethernet_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_ethernet_apis.c
@@ -111,10 +111,11 @@
 #include <utctx/utctx_api.h>
 #include "linux/sockios.h"
 #include <sys/ioctl.h>
+
 #ifdef ARRIS_XB3_PLATFORM_CHANGES
-  #include "rdk_cm_api_arris.h"
+#include "rdk_cm_api_arris.h"
 #else
-  #include "linux/if.h"
+#include <net/if.h>
 #endif
 
 #ifdef CORE_NET_LIB
@@ -337,11 +338,7 @@ CosaDmlEthInit
      *  It doesn't make sense to even have a MAC address in Ethernet Interface DM object,
      *  so we are not going to fill the MAC address for Upstream interfaces.
      */
-#ifdef ARRIS_XB3_PLATFORM_CHANGES
-    rdkb_api_platform_hal_GetLanMacAddr(strMac);
-#else
     _getMac("brlan0", strMac);
-#endif
 
     /*  Iterate through Ethernet ports, assign LAN mac to downstream ports
         Keep track of the index of upstream ports to assign their MAC addresses

--- a/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
@@ -2001,11 +2001,7 @@ void* restoreAllDBs(void* arg)
             else
             {
                 // we are the child
-#ifdef ARRIS_XB3_PLATFORM_CHANGES
-                char *args[] = {"rpcclient", urlPtr, "/bin/rm -f /nvram/syscfg.db /nvram/.keys/vyinerkyo.wyr", (char *) 0 };
-#else
                 char *args[] = {"rpcclient", urlPtr, "/bin/rm -f /nvram/syscfg.db", (char *) 0 };
-#endif
                 execv(args[0], args);
                 _exit(EXIT_FAILURE);   // exec never returns
             }
@@ -3433,14 +3429,6 @@ CosaDmlDcSetReinitMacThreshold
         ULONG                       value
     )
 {
-#ifdef ARRIS_XB3_PLATFORM_CHANGES
-    UNREFERENCED_PARAMETER(hContext);
-    if ( cm_hal_set_ReinitMacThreshold(value) != RETURN_OK )
-        return ANSC_STATUS_FAILURE;
-    else
-        return ANSC_STATUS_SUCCESS;
-
-#else
     UNREFERENCED_PARAMETER(hContext);
     char buf[12];
     errno_t safec_rc = -1;
@@ -3459,7 +3447,6 @@ CosaDmlDcSetReinitMacThreshold
     {
         return ANSC_STATUS_SUCCESS;
     }
-#endif
 }
 
 ANSC_STATUS
@@ -3469,14 +3456,6 @@ CosaDmlDcGetReinitMacThreshold
         ULONG                       *pValue
     )
 {
-#ifdef ARRIS_XB3_PLATFORM_CHANGES
-    UNREFERENCED_PARAMETER(hContext);
-    if ( cm_hal_get_ReinitMacThreshold(pValue) != RETURN_OK )
-        return ANSC_STATUS_FAILURE;
-    else
-        return ANSC_STATUS_SUCCESS;
-
-#else
     char buf[12];
 
     if( (syscfg_get( NULL, "rdkbReinitMacThreshold", buf, sizeof(buf))) == 0 )
@@ -3489,7 +3468,6 @@ CosaDmlDcGetReinitMacThreshold
     	CosaDmlDcSetReinitMacThreshold(hContext, *pValue);
     }
     return ANSC_STATUS_SUCCESS;
-#endif
 }
 
 ANSC_STATUS


### PR DESCRIPTION
RDKCOM-5442: RDKBDEV-3232 drop obsolete code conditional on ARRIS_XB3_PLATFORM_CHANGES

  for file in $(find . -type f -name '*.[ch]') ; do unifdef -B -UARRIS_XB3_PLATFORM_CHANGES -o $file $file ; done
Signed-off-by: Andre McCurdy <amccurdy@libertyglobal.com>