### PR TITLE
[RDKBDEV-3272](CDRouter - No response from DHPCv6 server in CM when LAN client sends Confirm message

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
@@ -5508,6 +5508,7 @@ void __cosa_dhcpsv6_refresh_config()
                     CcspTraceWarning(("_cosa_dhcpsv6_refresh_config -- g_GetParamValueString for iana:%d\n", returnValue));
                 }
 
+                fprintf(fp, "   subnet %s\n", prefixValue);
                 fprintf(fp, "   class {\n");
 
 #ifdef CONFIG_CISCO_DHCP6S_REQUIREMENT_FROM_DPC3825


### PR DESCRIPTION
[RDKBDEV-3272](CDRouter - No response from DHPCv6 server in CM when LAN client sends Confirm message

Reason for change: No response to DHCPv6 Confirm from the LAN client with an unknown IAID containing an unknown address, which is not сonsidered "on link".
Risks: Low
Signed-off-by: Aiswarya Prasad <aprasad@maxlinear.com>