### PR TITLE
XER10-2143: [Eco mode]5G and 6G BSSIDs are down after a reboot and FR.

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
@@ -2060,7 +2060,7 @@ void* restoreAllDBs(void* arg)
 	// set lastreboot reason directly into db
 #if defined (_SCER11BEL_PRODUCT_REQ_) || defined (_SCXF11BFL_PRODUCT_REQ_)
 /* run another cleanup just to make sure if above script did not clean it */
-        v_secure_system("rm -rf /data/.comcast_config_set.done /data/nvram_cfg.txt /data/psi* /data/.nvram_restore_cfg.txt /data/psi_wifi /data/.user_nvram.setting /data/onewifi_downgrade_required /data/.sky_config_set.done /nvram/.bcmwifi_xhs_lnf_enabled /nvram/secure/wifi/* /nvram/wifi/*");
+        v_secure_system("rm -rf /data/.comcast_config_set.done /data/nvram_cfg.txt /data/psi* /data/.nvram_restore_cfg.txt /data/psi_wifi /data/.user_nvram.setting /data/onewifi_downgrade_required /data/.sky_config_set.done /data/.no_preserve_kernel_nvram /data/.kernel_nvram.setting /nvram/.bcmwifi_xhs_lnf_enabled /nvram/secure/wifi/* /nvram/wifi/*; sync");
         //voice module will use HFRES_TELCOVOIP and HFRES_TELCOVOICE
         v_secure_system("echo 1 > /data/HFRES_TELCOVOIP;echo 2 > /data/HFRES_TELCOVOICE;");
         v_secure_system("sync; touch /data/.do_fr_on_boot; sync");
@@ -2699,7 +2699,7 @@ CosaDmlDcSetFactoryReset
 		v_secure_system("rm -f /opt/secure/wifi/rdkb-wifi.db"); //Need to remove wifi-db for Onewifi
 #if defined (_SCER11BEL_PRODUCT_REQ_) || defined (_SCXF11BFL_PRODUCT_REQ_)
 /* clean up BRCM nvram */
-        v_secure_system("rm -rf /data/.comcast_config_set.done /data/nvram_cfg.txt /data/psi* /data/.nvram_restore_cfg.txt /data/psi_wifi /data/.user_nvram.setting /data/onewifi_downgrade_required /data/.sky_config_set.done /nvram/.bcmwifi_xhs_lnf_enabled /nvram/secure/wifi/* /nvram/wifi/*");
+        v_secure_system("rm -rf /data/.comcast_config_set.done /data/nvram_cfg.txt /data/psi* /data/.nvram_restore_cfg.txt /data/psi_wifi /data/.user_nvram.setting /data/.no_preserve_kernel_nvram /data/.kernel_nvram.setting /data/onewifi_downgrade_required /data/.sky_config_set.done /nvram/.bcmwifi_xhs_lnf_enabled /nvram/secure/wifi/* /nvram/wifi/*");
         v_secure_system("sync; touch /data/.do_fr_on_boot; sync");
 #endif
 	}


### PR DESCRIPTION
Reason for change: XER10-1174 changes broke Eco mode due to kernel nvram setting
 didn't get preserved. From other BRCM wifi projects, rdkb never corrupted
 kernel_nvram.setting file and assumed factory process may have intruduce invalid
 kernel nvram setting.  This changes is to remove /data/.kernel_nvram.setting on first
 boot if there is no other known files created by RDKB.

Test Procedure:
Please be careful that you are running latest build or xer10 will end up in boot loop.
    1) create corrupted /data/.kernel_nvram.setting; "rm -rf /data/.kernel_nvram.setting; echo "123" > /data/.kernel_nvram.setting; sync; reboot -f"
    2) check if xer10 comes up correctly.
    3) run "nvram kset Hellow=World; nvram kcommit.
    4) Reboot, check "nvram kget Hellow" and it should return "World".
    5) perform Factory Default, and run step 4 but make sure nothing return this time

Change-Id: I488d5f20393086f4b040bc873e0bc26de855f3a8 Risks: Low
Signed-off-by: Robert_Lee2@comcast.com
(cherry picked from commit 59531e09eec6b4a40b16f9bfc9a5d5bee613c129)