### PR TITLE
XER10-2116: DML X_RDKCENTRAL-COM_InActiveFirmwarenot supported in XER10

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_deviceinfo_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_deviceinfo_apis.c
@@ -493,7 +493,7 @@ CosaDmlDiGetManufacturerOUI
 
 }
 
-#if !defined(_SR213_PRODUCT_REQ_) && !defined (_WNXL11BWL_PRODUCT_REQ_) && !defined(_SCER11BEL_PRODUCT_REQ_) && !defined(_SCXF11BFL_PRODUCT_REQ_)
+#if !defined(_SR213_PRODUCT_REQ_) && !defined (_WNXL11BWL_PRODUCT_REQ_)
 ANSC_STATUS
 CosaDmlDiGetInActiveFirmware
     (

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -1056,7 +1056,7 @@ DeviceInfo_GetParamStringValue
         return 0;
     }
 
-#if !defined(_SR213_PRODUCT_REQ_) && !defined (_WNXL11BWL_PRODUCT_REQ_) && !defined (_SCER11BEL_PRODUCT_REQ_) && !defined (_SCXF11BFL_PRODUCT_REQ_)
+#if !defined(_SR213_PRODUCT_REQ_) && !defined (_WNXL11BWL_PRODUCT_REQ_)
     if (strcmp(ParamName, "X_RDKCENTRAL-COM_InActiveFirmware") == 0)
     {
         return CosaDmlDiGetInActiveFirmware(NULL, pValue, pulSize);


### PR DESCRIPTION
Reason for change:
The DML Device.DeviceInfo.X_RDKCENTRAL-COM_InActiveFirmware returns empty value. This dml is used for operational purposes to know about firmware in-active banks.

Test Procedure:
Check Device.DeviceInfo.X_RDKCENTRAL-COM_InActiveFirmware Risks: Low
Priority: P1
Signed-off-by: Robert_Lee2@comcast.com

Change-Id: Ia3007c0cbb5d6ec8b7c4eaafe10fc82118f2d53f (cherry picked from commit a4b46dd2554fb98765d700c2445592fe5bc8be68)