### PR TITLE
XER10-1174: move .kernel_nvram.setting under /tmp instead of /data

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
@@ -2060,7 +2060,7 @@ void* restoreAllDBs(void* arg)
 	// set lastreboot reason directly into db
 #if defined (_SCER11BEL_PRODUCT_REQ_) || defined (_SCXF11BFL_PRODUCT_REQ_)
 /* run another cleanup just to make sure if above script did not clean it */
-        v_secure_system("rm -rf /data/.comcast_config_set.done /data/nvram_cfg.txt /data/psi* /data/.nvram_restore_cfg.txt /data/psi_wifi /data/.user_nvram.setting /data/onewifi_downgrade_required /data/.sky_config_set.done /nvram/.bcmwifi_xhs_lnf_enabled /nvram/secure/wifi/* /nvram/wifi/*");
+        v_secure_system("rm -rf /data/.comcast_config_set.done /data/nvram_cfg.txt /data/psi* /data/.nvram_restore_cfg.txt /data/psi_wifi /data/.user_nvram.setting /data/onewifi_downgrade_required /data/.sky_config_set.done /data/.preserve_kernel_nvram /data/.kernel_nvram.setting /nvram/.bcmwifi_xhs_lnf_enabled /nvram/secure/wifi/* /nvram/wifi/*");
         //voice module will use HFRES_TELCOVOIP and HFRES_TELCOVOICE
         v_secure_system("echo 1 > /data/HFRES_TELCOVOIP;echo 2 > /data/HFRES_TELCOVOICE;");
         v_secure_system("sync; touch /data/.do_fr_on_boot; sync");


### PR DESCRIPTION
Reason for change: create .kernel_nvram.setting on every boot because
  for unknown reason /data/.kernel_nvram.setting get corrupted and
  result in dhd_trap and reboot loop during dhdpcie_bus_read_pcie_ipc.
  Also, add logic to use preserve kernel_nvram.setting during debug and
  develop feature and add factory default cleanup code.

Test Procedure:
  1) check "ls -al /data/.kernel_nvram.setting" is symbolic link and
     wifi comes up correctly.
  2) touch /data/.preserve_kernel_nvram and reboot.
     check "ls -al /data/.kernel_nvram.setting" is actual file, and
     wifi comes up correctly.

Risks:low

Change-Id: I420376caccf734bd56fecd60bc30d3c86588d80b Signed-off-by: Robert_Lee2@comcast.com
(cherry picked from commit 6047a0ae695431a77e08cf450042fc0aa96b0488)