### PR TITLE
RDKBDEV-3274: Fix compilation error from CosaDmlUserResetPassword() in ccsp-p-and-m

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_users_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_users_apis.c
@@ -726,7 +726,9 @@ CosaDmlUserResetPassword
    UNREFERENCED_PARAMETER(bValue);
    CcspTraceWarning(("%s, Entered Reset function\n",__FUNCTION__)); 
    char defPassword[10];
+#if defined(_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)  || defined(_PLATFORM_BANANAPI_R4_) || defined(LIBRDKCONFIG_BUILD) || (defined(_COSA_FOR_BCI_) &&  defined(LIBRDKCONFIG_BUILD))
    errno_t safec_rc = -1;
+#endif
    if(!strcmp(pEntry->Username,"admin"))
    {
 #if defined(_HUB4_PRODUCT_REQ_) || defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)  || defined(_PLATFORM_BANANAPI_R4_)


### PR DESCRIPTION
Reason for change: While building RDKB 25Q2 kirkstone, we observed that ccsp-p-and-m fails with compilation error in CosaDmlUserResetPassword().
Risks: Low
Signed-off-by: Aiswarya Prasad <aprasad@maxlinear.com>