### PR TITLE
RDKB-59581: Region Check Feature for XER10 UK - Bringup missing change into github

### DIFF
--- a/arch/intel_usg/boards/arm_shared/scripts/partners_defaults.json
+++ b/arch/intel_usg/boards/arm_shared/scripts/partners_defaults.json
@@ -2,7 +2,7 @@
    "properties" : {
 
       "comments" : "MANDATORY: !!! Please increment below version value for any new parameter added in this partners_defaults.json !!!",
-      "version" : "8.31"
+      "version" : "8.32"
    },
 
    "comcast" : {
@@ -446,7 +446,8 @@
                 "Device.X_RDK_WebConfig.SupplementaryServiceUrls.Telemetry" : "https://cpe-profile-sky-uk.wp.xdp.comcast.net/api/v1/device/{mac}/config",
                 "Device.X_RDKCENTRAL-COM_Webpa.Server.URL" : "https://fabric.xmidt-eu.comcast.net:8080",
                 "Device.X_RDKCENTRAL-COM_Webpa.TokenServer.URL" : "https://issuer.xmidt-eu.comcast.net:8080/issue",
-                "Device.X_RDKCENTRAL-COM_Webpa.DNSText.URL" : "fabric.xmidt-eu.comcast.net"
+                "Device.X_RDKCENTRAL-COM_Webpa.DNSText.URL" : "fabric.xmidt-eu.comcast.net",
+                "Device.WiFi.X_RDKCENTRAL-COM_Syndication.WiFiRegion.Code" : "IE"
         }
       },
       "apply_value_to_sysevent" : {

--- a/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
@@ -2064,6 +2064,8 @@ void* restoreAllDBs(void* arg)
         //voice module will use HFRES_TELCOVOIP and HFRES_TELCOVOICE
         v_secure_system("echo 1 > /data/HFRES_TELCOVOIP;echo 2 > /data/HFRES_TELCOVOICE;");
         v_secure_system("sync; touch /data/.do_fr_on_boot; sync");
+	//Remove region default countrycode file.
+	v_secure_system("rm -rf /nvram/CountryCode");
 #endif
         v_secure_system("mkdir -p /nvram/secure/data/ && touch $_/syscfg.db");
         v_secure_system("echo \"X_RDKCENTRAL-COM_LastRebootReason=factory-reset\" > /nvram/secure/data/syscfg.db");


### PR DESCRIPTION
Reason for change: This commit mainly includes add a support for the region check based on Xconf response and set the country code for wifi interfaces.

Bringup the missing change into sprint branch.

Here this change mainly includes:
1. By default, country code should be IE (Ireland).
2. Based on RFC response, adjust the country code based on region information received from Xconf.
3. Persist the information.
4. Clear upon FR.

Test Procedure:
1. Check default country code - it should be IE
2. Check its changes to GB for UK region device after 2-3 minutes
3. Reboot and make sure it is GB.
4. FR, and check the steps (1) and (2)

Priority:P1