### PR TITLE
XF10-135: Remove CM HAL dependency from CcspPandM

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
@@ -182,7 +182,9 @@ int fwSync = 0;
 #include "syscfg/syscfg.h"
 
 #include "platform_hal.h"
+#ifndef PON_GATEWAY
 #include "cm_hal.h"
+#endif
 
 #define HTTPD_CONF      "/var/lighttpd.conf"
 #define HTTPD_DEF_CONF  "/etc/lighttpd.conf"
@@ -864,7 +866,7 @@ CosaDmlDcGetWanStaticIPAddress
 ANSC_STATUS 
 CosaDmlDcSetReInitCmMac ()
 {
-
+#ifndef PON_GATEWAY
     if(cm_hal_ReinitMac() == 0)
     {
        return ANSC_STATUS_SUCCESS;
@@ -873,7 +875,8 @@ CosaDmlDcSetReInitCmMac ()
     {
        return ANSC_STATUS_FAILURE;
     }
-    
+#endif
+    return ANSC_STATUS_FAILURE;
 }
 ANSC_STATUS
 CosaDmlDcGetWanStaticSubnetMask

--- a/source/TR-181/include/cosa_x_cisco_com_devicecontrol_apis.h
+++ b/source/TR-181/include/cosa_x_cisco_com_devicecontrol_apis.h
@@ -707,7 +707,9 @@ void* CosaDmlDcRebootWifi(ANSC_HANDLE   hContext);
 void* CosaDmlDcRestartRouter(void* arg);
 void CosaDmlDcSaveWiFiHealthStatusintoNVRAM( void  );
 int CheckAndGetDevicePropertiesEntry( char *pOutput, int size, char *sDevicePropContent );
+#ifndef PON_GATEWAY
 INT cm_hal_ReinitMac();
+#endif
 BOOL moca_HardwareEquipped(void);
 
 ANSC_STATUS

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -3676,7 +3676,7 @@ Snmpv3DHKickstart_SetParamBoolValue
         CcspTraceInfo(("Snmpv3DHKickstart_SetParamBoolValue: successfully set %s = %s\n", ParamName, bValue == TRUE ? "TRUE" : "FALSE"));
         if( pKickstart->TableUpdated == TRUE && pKickstart->Enabled == TRUE )
         {
-#if !defined(_XER5_PRODUCT_REQ_) && !defined(_SR213_PRODUCT_REQ_)
+#if !defined(_XER5_PRODUCT_REQ_) && !defined(_SR213_PRODUCT_REQ_) && !defined(PON_GATEWAY)
 	    i = cm_hal_snmpv3_kickstart_initialize( &Snmpv3_Kickstart_Table );
             CcspTraceError(("cm_hal_snmpv3_kickstart_initialize: return value = %d\n", i));
             pKickstart->TableUpdated = FALSE;


### PR DESCRIPTION
Reason for change: XF10 is not CM based device , so its not required a CM HAL , so protect CM HAL calls in non CM devices to avoid the link error.

Test Procedure: Make sure not compilation or runtime error for CcspPandM.

Priority:P1