### PR TITLE
RDKB-61769: [ccsp-p-and-m] remove _64BIT_ARCH_SUPPORT_ macro

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
@@ -2973,11 +2973,7 @@ static int _write_dibbler_sent_option_file(void)
         for (i=0; i<g_sent_option_num; i++)
         {
             if (g_sent_options[i].bEnabled)
-#if !defined(_64BIT_ARCH_SUPPORT_)
-                    fprintf(fp, "%lu:%d:%s\n",
-#else
                     fprintf(fp, "%lu:%zu:%s\n",
-#endif
                         g_sent_options[i].Tag,
                         strlen((const char*)g_sent_options[i].Value)/2,
                         g_sent_options[i].Value);
@@ -11004,11 +11000,7 @@ dhcpv6c_dbg_thrd(void * in)
                             if (strlen(globalIP2) != 0 )
                             {
                                 g_dhcpv6s_refresh_count = bRestartLan;
-#if !defined(_64BIT_ARCH_SUPPORT_)
-				CcspTraceWarning(("%s: g_dhcpv6s_refresh_count %ld, globalIP2 is %s, strlen is %d\n", __func__, g_dhcpv6s_refresh_count,globalIP2,strlen(globalIP2)));
-#else
 				CcspTraceWarning(("%s: g_dhcpv6s_refresh_count %ld, globalIP2 is %s, strlen is %zu\n", __func__, g_dhcpv6s_refresh_count,globalIP2,strlen(globalIP2)));
-#endif
 			    }
 
                             rc = strcpy_s(globalIP2, sizeof(globalIP2), globalIP);

--- a/source-arm/TR-181/board_sbapi/cosa_managedwifi_webconfig_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_managedwifi_webconfig_apis.c
@@ -2358,11 +2358,7 @@ void getBridgeDetailsFromPsm(void)
     }
 
     snprintf(aParamName, BUFF_LEN_64, l2netBridgeName, sManageWiFiInfo.aBridgeIndex);
-#if !defined(_64BIT_ARCH_SUPPORT_)
-    CcspTraceInfo(("%s: aBridgeName=%d\n", __FUNCTION__,sizeof(sManageWiFiInfo.aBridgeName)));
-#else
     CcspTraceInfo(("%s: aBridgeName=%zu\n", __FUNCTION__,sizeof(sManageWiFiInfo.aBridgeName)));
-#endif
     CcspTraceInfo(("%s: aParamName=%s\n", __FUNCTION__,aParamName));
 
     /* CID 347167 Unchecked return value fix */

--- a/source-arm/TR-181/board_sbapi/cosa_upnp_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_upnp_apis.c
@@ -289,11 +289,7 @@ CosaDmlUpnpDevGetAdvPeriod
 	Utopia_RawGet(&utctx, NULL, "upnp_igd_advr_expire", buf, sizeof(buf));
     
 	if (AnscSizeOfString(buf)){
-#if !defined(_64BIT_ARCH_SUPPORT_)
-		*val = (PULONG)_ansc_atoi(buf);
-#else
-		*val = (PULONG)_ansc_atol(buf);
-#endif
+		*val = (PULONG)*val = (PULONG)strtoul(buf, NULL, 10);
 	}else{
 		*val = (PULONG)g_AdvPeriod; // use default value
 	}
@@ -348,11 +344,7 @@ CosaDmlUpnpDevGetTTL
 	Utopia_RawGet(&utctx, NULL, "upnp_igd_advr_ttl", buf, sizeof(buf));
     
 	if (AnscSizeOfString(buf)){
-#if !defined(_64BIT_ARCH_SUPPORT_)
-		*val = (PULONG)_ansc_atoi(buf);
-#else
-		*val = (PULONG)_ansc_atol(buf);
-#endif
+		*val = (PULONG)strtoul(buf, NULL, 10);
 	}else{
 		*val = (PULONG)g_TTL; // use default value
 	}

--- a/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_security_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_security_apis.c
@@ -2436,11 +2436,7 @@ static int be_struct_2_middle_layer(iap_entry_t * p_in, PCOSA_DML_IA_POLICY p_ou
     p_out->LanHost.IpCount      = p_in->lanhosts.ip_count;
     p_out->LanHost.IprCount     = p_in->lanhosts.iprange_count;    
 
-#if !defined(_64BIT_ARCH_SUPPORT_)
-    printf("sizeof(iap_entry_t) %d \n", sizeof(iap_entry_t)); 
-#else
     printf("sizeof(iap_entry_t) %zu \n", sizeof(iap_entry_t)); 
-#endif
 
     for (i=0; i<p_out->LanHost.MacCount && i<COSA_DML_IA_LH_MAX_MAC; i++)
     {

--- a/source-arm/TR-181/board_sbapi/speedboost_webconfig_apis.c
+++ b/source-arm/TR-181/board_sbapi/speedboost_webconfig_apis.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <inttypes.h>
 #include "ansc_platform.h"
 #include "webconfig_framework.h"
 #include "cosa_webconfig_api.h"
@@ -91,11 +92,7 @@ bool validateUnixTime(int64_t unixTime, char * pErrMessage, int iSizeOfBuffer)
     bool bRet = true;
 
     currentTime = (int64_t)time(NULL);
-#ifdef _64BIT_ARCH_SUPPORT_
-    CcspTraceInfo(("%s:%d, unixTime = %ld\n", __FUNCTION__, __LINE__, unixTime));
-#else
-    CcspTraceInfo(("%s:%d, unixTime = %lld\n", __FUNCTION__, __LINE__, unixTime));
-#endif
+    CcspTraceInfo(("%s:%d, unixTime = %" PRId64  "\n", __FUNCTION__, __LINE__, unixTime));
     if (unixTime > (currentTime + NINETY_DAYS_IN_SECONDS))
     {
         CcspTraceError (("%s:%d, The Unix time is more than 90 days from now.\n", __FUNCTION__, __LINE__));
@@ -222,13 +219,8 @@ pErr processSpeedBoostWebConfigRequest(void *pVoidData)
         snprintf(execRetVal->ErrorMsg, sizeof(execRetVal->ErrorMsg) - 1, "%s", "NULL pointer passed for absolute");
         return execRetVal;
     }
-#ifdef _64BIT_ARCH_SUPPORT_
-    CcspTraceInfo(("%s:%d, Number of Unix Time: %ld\n", __FUNCTION__, __LINE__, pSpeedBoostDoc->pSchedulerInfo->absolute_size));
-    CcspTraceInfo(("%s:%d, Number of Mac Addresses: %ld\n", __FUNCTION__, __LINE__, pSpeedBoostDoc->pSchedulerInfo->actions_size));
-#else
-    CcspTraceInfo(("%s:%d, Number of Unix Time: %d\n", __FUNCTION__, __LINE__, pSpeedBoostDoc->pSchedulerInfo->absolute_size));
-    CcspTraceInfo(("%s:%d, Number of Mac Addresses: %d\n", __FUNCTION__, __LINE__, pSpeedBoostDoc->pSchedulerInfo->actions_size));
-#endif
+    CcspTraceInfo(("%s:%d, Number of Unix Time: %zu\n", __FUNCTION__, __LINE__, pSpeedBoostDoc->pSchedulerInfo->absolute_size));
+    CcspTraceInfo(("%s:%d, Number of Mac Addresses: %zu\n", __FUNCTION__, __LINE__, pSpeedBoostDoc->pSchedulerInfo->actions_size));
 
     for (size_t iVar = 0; iVar < pSpeedBoostDoc->pSchedulerInfo->absolute_size; iVar++)
     {
@@ -245,11 +237,7 @@ pErr processSpeedBoostWebConfigRequest(void *pVoidData)
 
     if (MAX_MAC_ADDR_COUNT < pSpeedBoostDoc->pSchedulerInfo->actions_size)
     {
-#ifdef _64BIT_ARCH_SUPPORT_
-    	CcspTraceError(("%s:%d, Number of Mac Addresses(%ld) exceeds the limit\n", __FUNCTION__, __LINE__, pSpeedBoostDoc->pSchedulerInfo->actions_size));
-#else
-	CcspTraceError(("%s:%d, Number of Mac Addresses(%d) exceeds the limit\n", __FUNCTION__, __LINE__, pSpeedBoostDoc->pSchedulerInfo->actions_size));
-#endif
+    	CcspTraceError(("%s:%d, Number of Mac Addresses(%zu) exceeds the limit\n", __FUNCTION__, __LINE__, pSpeedBoostDoc->pSchedulerInfo->actions_size));
 	execRetVal->ErrorCode = VALIDATION_FALIED;
         snprintf(execRetVal->ErrorMsg, sizeof(execRetVal->ErrorMsg) - 1, "%s", "Number of Mac Addresses exceeds the limit");
         return execRetVal;
@@ -284,11 +272,7 @@ pErr processSpeedBoostWebConfigRequest(void *pVoidData)
         else
         {
             iSpeedBoostClientsCount++;
-#ifdef _64BIT_ARCH_SUPPORT_
-	    CcspTraceInfo(("%s:%d, MAC Address[%ld]:%s is Valid\n", __FUNCTION__, __LINE__, iVar, pMac));
-#else
-	    CcspTraceInfo(("%s:%d, MAC Address[%d]:%s is Valid\n", __FUNCTION__, __LINE__, iVar, pMac));
-#endif
+	    CcspTraceInfo(("%s:%d, MAC Address[%zu]:%s is Valid\n", __FUNCTION__, __LINE__, iVar, pMac));
 	    free(pMac);
         }
     }

--- a/source/TR-181/middle_layer_src/cosa_apis_util.c
+++ b/source/TR-181/middle_layer_src/cosa_apis_util.c
@@ -1009,11 +1009,7 @@ CosaUtilConstructLowerLayers
         }
     }
 
-#if !defined(_64BIT_ARCH_SUPPORT_)
-    AnscTraceFlow(("%s, size %d, buf len %lu\n", pLowerLayersBuf, _ansc_strlen(pLowerLayersBuf), *pBufLen));
-#else
     AnscTraceFlow(("%s, size %zu, buf len %lu\n", pLowerLayersBuf, _ansc_strlen(pLowerLayersBuf), *pBufLen));
-#endif
     return  ANSC_STATUS_SUCCESS;
 }
 

--- a/source/TR-181/middle_layer_src/cosa_dhcpv4_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_dhcpv4_dml.c
@@ -3941,11 +3941,7 @@ Server_SetParamStringValue
             }
             if (NULL != pStaticClients)
             {
-#if !defined(_64BIT_ARCH_SUPPORT_)
-                CcspTraceWarning(("pStaticClients->entries_count is %u\n", pStaticClients->entries_count));
-#else
                 CcspTraceWarning(("pStaticClients->entries_count is %zu\n", pStaticClients->entries_count));
-#endif
 
                 CcspTraceWarning(("pStaticClients->subdoc_name is %s\n", pStaticClients->subdoc_name));
                 CcspTraceWarning(("pStaticClients->version is %lu\n", (unsigned long)pStaticClients->version));
@@ -4036,11 +4032,7 @@ Server_SetParamStringValue
             if (NULL != pLanInfo)
             {
 		        pLanInfo->entries_count = 1;// Assigned 1 by default.
-#if !defined(_64BIT_ARCH_SUPPORT_)
-                CcspTraceWarning(("pLanInfo->entries_count is %u\n", pLanInfo->entries_count));
-#else
                 CcspTraceWarning(("pLanInfo->entries_count is %zu\n", pLanInfo->entries_count));
-#endif
                 CcspTraceWarning(("pLanInfo->subdoc_name is %s\n", pLanInfo->subdoc_name));
                 CcspTraceWarning(("pLanInfo->version is %lu\n", (unsigned long)pLanInfo->version));
                 CcspTraceWarning(("pLanInfo->transaction_id is %d\n", pLanInfo->transaction_id));
@@ -6088,11 +6080,7 @@ Pool_GetParamStringValue
             CosaDmlDhcpsGetPoolCfg(NULL,&tmpCfg);
             snprintf(pValue,sizeof(tmpCfg.DomainName),"%s", tmpCfg.DomainName);
         }else {
-#if !defined(_64BIT_ARCH_SUPPORT_)
-	  CcspTraceWarning(("%s: pPool->Cfg.DomainName: %s  0x%1x 0x%1x 0x%1x 0x%1x, sizeof: %d\n", 
-#else
 	  CcspTraceWarning(("%s: pPool->Cfg.DomainName: %s  0x%1x 0x%1x 0x%1x 0x%1x, sizeof: %zu\n",
-#endif
 			    __FUNCTION__, pPool->Cfg.DomainName, (signed) (pPool->Cfg.DomainName[0]), 
 			    (signed) (pPool->Cfg.DomainName[1]), (signed) (pPool->Cfg.DomainName[2]), 
 			    (signed) (pPool->Cfg.DomainName[3]), sizeof(pPool->Cfg.DomainName)));
@@ -7948,11 +7936,7 @@ StaticAddress_SetParamStringValue
     	}
 		else
 		{
-#if !defined(_64BIT_ARCH_SUPPORT_)
-			CcspTraceWarning(("'%s' value should be less than (%d) charecters\n", ParamName, ( sizeof(pDhcpStaticAddress->DeviceName) - 1 )));
-#else
 			CcspTraceWarning(("'%s' value should be less than (%zu) charecters\n", ParamName, ( sizeof(pDhcpStaticAddress->DeviceName) - 1 )));
-#endif
 		}
     }
 
@@ -7971,11 +7955,7 @@ StaticAddress_SetParamStringValue
         }
         else
         {
-#if !defined(_64BIT_ARCH_SUPPORT_)
-            CcspTraceWarning(("'%s' value should be less than (%d) charecters\n", ParamName, ( sizeof(pDhcpStaticAddress->Comment) - 1 )));
-#else
             CcspTraceWarning(("'%s' value should be less than (%zu) charecters\n", ParamName, ( sizeof(pDhcpStaticAddress->Comment) - 1 )));
-#endif
         }
     }
 

--- a/source/TR-181/middle_layer_src/cosa_nat_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_nat_dml.c
@@ -2963,11 +2963,7 @@ X_RDK_PortMapping_SetParamStringValue
 		{
 
 
-#if !defined(_64BIT_ARCH_SUPPORT_)
-			CcspTraceWarning(("rpm->entries_count is %u\n", rpm->entries_count));
-#else
 			CcspTraceWarning(("rpm->entries_count is %zu\n", rpm->entries_count));
-#endif
 			CcspTraceWarning(("rpm->subdoc_name is %s\n", rpm->subdoc_name));
 			CcspTraceWarning(("rpm->version is %lu\n", (unsigned long)rpm->version));
 			CcspTraceWarning(("rpm->transaction_id is %d\n", rpm->transaction_id));

--- a/source/TR-181/middle_layer_src/cosa_routing_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_routing_dml.c
@@ -1402,11 +1402,7 @@ X_CISCO_COM_StaticIPv4Forwarding_AddEntry
     *pInsNumber                    = pCxtLink->InstanceNumber;
 
     /* We give a permenant name here*/
-#if !defined(_64BIT_ARCH_SUPPORT_)
-    rc = sprintf_s(pEntry->Name, sizeof(pEntry->Name),"StaticRoute_%x_%lu", (UINT)pEntry, pCxtLink->InstanceNumber );
-#else
     rc = sprintf_s(pEntry->Name, sizeof(pEntry->Name),"StaticRoute_%p_%lu", pEntry, pCxtLink->InstanceNumber );
-#endif
     if(rc < EOK)
     {
       ERR_CHK(rc);

--- a/source/TR-181/middle_layer_src/cosa_webconfig_api.c
+++ b/source/TR-181/middle_layer_src/cosa_webconfig_api.c
@@ -450,11 +450,7 @@ int set_portmap_conf(portmappingdoc_t *rpm)
     	int pfr_count = 0;
     	char alias_pre[8];
         errno_t  rc   = -1;
-#if !defined(_64BIT_ARCH_SUPPORT_)
-    	printf("Port map entries %d\n",rpm->entries_count);
-#else
         printf("Port map entries %zu\n",rpm->entries_count);
-#endif
     	//printf("SinglePortForwardCount = %d\n", rpm->entries_count);
     	//count = rpm->entries_count + 1;
     	for(i = 1,j =0; i < rpm->entries_count+1; i++, j++ )
@@ -704,11 +700,7 @@ pErr Process_PF_WebConfigRequest(void *Data)
     	portmappingdoc_t *rpm = (portmappingdoc_t *) Data ;
 
 
-#if !defined(_64BIT_ARCH_SUPPORT_)
-        CcspTraceWarning(("rpm->entries_count is %d\n", rpm->entries_count));
-#else
         CcspTraceWarning(("rpm->entries_count is %zu\n", rpm->entries_count));
-#endif
     	CcspTraceWarning(("Portmap configurartion recieved\n"));
 
 

--- a/source/TR-181/middle_layer_src/cosa_x_cisco_com_ddns_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_x_cisco_com_ddns_dml.c
@@ -1687,11 +1687,7 @@ Service_SetParamStringValue
         }
         else
         {
-#if !defined(_64BIT_ARCH_SUPPORT_)
-            CcspTraceWarning(("'%s' value should be less than (%d) charecters\n", ParamName, sizeof(pDdnsService->AssociatedConnection) ));
-#else
             CcspTraceWarning(("'%s' value should be less than (%zu) charecters\n", ParamName, sizeof(pDdnsService->AssociatedConnection) ));
-#endif
             return FALSE;
         }
     }
@@ -1710,11 +1706,7 @@ Service_SetParamStringValue
         }
         else
         {
-#if !defined(_64BIT_ARCH_SUPPORT_)
-            CcspTraceWarning(("'%s' value should be less than (%d) charecters\n", ParamName, sizeof(pDdnsService->Alias) ));
-#else
             CcspTraceWarning(("'%s' value should be less than (%zu) charecters\n", ParamName, sizeof(pDdnsService->Alias) ));
-#endif
             return FALSE;
         }
 
@@ -1734,11 +1726,7 @@ Service_SetParamStringValue
         }
         else
         {
-#if !defined(_64BIT_ARCH_SUPPORT_)
-            CcspTraceWarning(("'%s' value should be less than (%d) charecters\n", ParamName, sizeof(pDdnsService->Domain) ));
-#else
             CcspTraceWarning(("'%s' value should be less than (%zu) charecters\n", ParamName, sizeof(pDdnsService->Domain) ));
-#endif
             return FALSE;
         }
     }
@@ -1757,11 +1745,7 @@ Service_SetParamStringValue
         }
         else
         {
-#if !defined(_64BIT_ARCH_SUPPORT_)
-            CcspTraceWarning(("'%s' value should be less than (%d) charecters\n", ParamName, sizeof(pDdnsService->Password) ));
-#else
             CcspTraceWarning(("'%s' value should be less than (%zu) charecters\n", ParamName, sizeof(pDdnsService->Password) ));
-#endif
             return FALSE;
         }
     }
@@ -1780,11 +1764,7 @@ Service_SetParamStringValue
         }
         else
         {
-#if !defined(_64BIT_ARCH_SUPPORT_)
-            CcspTraceWarning(("'%s' value should be less than (%d) charecters\n", ParamName, sizeof(pDdnsService->Username) ));
-#else
             CcspTraceWarning(("'%s' value should be less than (%zu) charecters\n", ParamName, sizeof(pDdnsService->Username) ));
-#endif
             return FALSE;
         }
     }
@@ -1803,11 +1783,7 @@ Service_SetParamStringValue
         }
         else
         {
-#if !defined(_64BIT_ARCH_SUPPORT_)
-            CcspTraceWarning(("'%s' value should be less than (%d) charecters\n", ParamName, sizeof(pDdnsService->Mail_exch) ));
-#else
             CcspTraceWarning(("'%s' value should be less than (%zu) charecters\n", ParamName, sizeof(pDdnsService->Mail_exch) ));
-#endif
             return FALSE;
         }
     }

--- a/source/TR-181/middle_layer_src/speedBoostDoc.c
+++ b/source/TR-181/middle_layer_src/speedBoostDoc.c
@@ -90,13 +90,8 @@ input_t* createScheduleInput(size_t iActionExecCount)
 
     if (iActionExecCount > iMaxActions)
     {
-#ifdef _64BIT_ARCH_SUPPORT_
-        CcspTraceError(("create_schedule_input() Error Request %ld exceeds maximum %ld\n",
+        CcspTraceError(("create_schedule_input() Error Request %zu exceeds maximum %zu\n",
                      iActionExecCount, iMaxActions));
-#else
-	CcspTraceError(("create_schedule_input() Error Request %d exceeds maximum %d\n",
-                     iActionExecCount, iMaxActions));
-#endif
         return pScheduleInfo;
     }
 


### PR DESCRIPTION
Reason for change: remove 64BIT_ARCH_SUPPORT
macro from ccsp-p-and-m module
Test Procedure: No build warning or errors.
basic sanity
Priority: P1
Risks: Low