### PR TITLE
RDKCOM-5532: RDKBDEV-3366 Bug fixes and feature updates for IPQ-based devices

### DIFF
--- a/config-arm/TR181-USGv2.XML
+++ b/config-arm/TR181-USGv2.XML
@@ -15057,7 +15057,66 @@
       </parameters>
       
       <objects>
-        
+<?ifdef _COSA_QCA_ARM_?>
+        <object>
+            <name>X_IPQ_McProxy</name>
+            <objectType>writableTable</objectType>
+            <functions>
+                <func_GetEntryCount>X_IPQ_McProxy_GetEntryCount</func_GetEntryCount>
+                <func_GetEntry>X_IPQ_McProxy_GetEntry</func_GetEntry>
+                <func_GetParamBoolValue>X_IPQ_McProxy_GetParamBoolValue</func_GetParamBoolValue>
+                <func_GetParamStringValue>X_IPQ_McProxy_GetParamStringValue</func_GetParamStringValue>
+                <func_SetParamBoolValue>X_IPQ_McProxy_SetParamBoolValue</func_SetParamBoolValue>
+                <func_SetParamStringValue>X_IPQ_McProxy_SetParamStringValue</func_SetParamStringValue>
+                <func_Validate>X_IPQ_McProxy_Validate</func_Validate>
+               <func_Commit>X_IPQ_McProxy_Commit</func_Commit>
+            </functions>
+            <parameters>
+                <parameter>
+                    <name>Enable</name>
+                    <type>boolean</type>
+                    <syntax>bool</syntax>
+                   <writable>true</writable>
+                </parameter>
+                <parameter>
+                    <name>Protocol</name>
+                    <type>string</type>
+                    <syntax>string</syntax>
+                    <writable>true</writable>
+                </parameter>
+                <parameter>
+                    <name>Upstream</name>
+                    <type>string(64)</type>
+                    <syntax>string</syntax>
+                    <writable>true</writable>
+                </parameter>
+                <parameter>
+                    <name>Downstream</name>
+                    <type>string(64)</type>
+                    <syntax>string</syntax>
+                    <writable>true</writable>
+                </parameter>
+                <parameter>
+                    <name>Name</name>
+                    <type>string(64)</type>
+                    <syntax>string</syntax>
+                    <writable>true</writable>
+                </parameter>
+                <parameter>
+                    <name>X_IPQ_McProxy_IPv6_brlan_IP</name>
+                    <type>string</type>
+                    <syntax>string/ip6_addr</syntax>
+                    <writable>true</writable>
+                </parameter>
+                <parameter>
+                    <name>ApplySettings</name>
+                    <type>boolean</type>
+                    <syntax>bool</syntax>
+                    <writable>true</writable>
+                </parameter>
+            </parameters>
+        </object>
+<?endif?>
         <object>
             
           <name>LanManagementEntry</name>

--- a/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
@@ -1871,6 +1871,9 @@ CosaDmlDcSetRebootDevice
             	CosaDmlDcSaveWiFiHealthStatusintoNVRAM( );
             	sleep (delay_time);
             	v_secure_system("/rdklogger/backupLogs.sh &");
+#if defined (_COSA_QCA_ARM_)
+                system("(sleep 5 && reboot) &");
+#endif
         	}
         	else
             {
@@ -1880,6 +1883,9 @@ CosaDmlDcSetRebootDevice
 				CosaDmlDcSaveWiFiHealthStatusintoNVRAM( );
 				sleep(5);
 				v_secure_system("/rdklogger/backupLogs.sh &");
+#if defined (_COSA_QCA_ARM_)
+                system("(sleep 5 && reboot) &");
+#endif
             }
 		}
 		else {
@@ -1888,6 +1894,9 @@ CosaDmlDcSetRebootDevice
 	         //system("reboot");
  			 CosaDmlDcSaveWiFiHealthStatusintoNVRAM( );
 	         v_secure_system("/rdklogger/backupLogs.sh &");
+#if defined (_COSA_QCA_ARM_)
+             system("reboot");
+#endif
 	    }
     }
 
@@ -2383,13 +2392,26 @@ CosaDmlDcSetFactoryReset
 	   	CcspTraceError(("FactoryReset:%s BAD parameter passed to factory defaults parameter ...\n",__FUNCTION__));
 		return ANSC_STATUS_BAD_PARAMETER;
 	    }
-#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR_PRODUCT_REQ_)) && defined (_COSA_BCM_ARM_) || defined (_HUB4_PRODUCT_REQ_) || defined (_PLATFORM_RASPBERRYPI_) || defined(_COSA_BCM_MIPS_) || defined(_XER5_PRODUCT_REQ_) || defined (_PLATFORM_BANANAPI_R4_)
+#if (defined (_XB6_PRODUCT_REQ_) || defined (_CBR_PRODUCT_REQ_)) && defined (_COSA_BCM_ARM_) || defined (_HUB4_PRODUCT_REQ_) || defined (_PLATFORM_RASPBERRYPI_) || defined(_COSA_BCM_MIPS_) || defined(_XER5_PRODUCT_REQ_) || defined (_PLATFORM_BANANAPI_R4_) || defined(_COSA_QCA_ARM_)
                 {
                         unsigned int dbValue = 0;
                         FILE *pdbFile = NULL;
                         char buf[128]={0};
                         #define FACTORY_RESET_COUNT_FILE "/nvram/.factory_reset_count"
                         pdbFile = fopen(FACTORY_RESET_COUNT_FILE, "r");
+#ifdef _COSA_QCA_ARM_
+                        size_t bytesRead = 0;
+                        if(pdbFile != NULL){
+                            bytesRead = fread(buf, 1, sizeof(buf) - 1, pdbFile);
+                            if (bytesRead == 0 || ferror(pdbFile)) {
+                                CcspTraceError(("[%s]: Failed to read\n", __FUNCTION__));
+                            } else {
+                                buf[bytesRead] = '\0';
+                                dbValue = (unsigned int)strtoul(buf, NULL, 10);
+                            }
+                           fclose(pdbFile);
+                        }
+#else
                         /* CID 79131 - Ignoring number of bytes read : fix */
                         if(pdbFile != NULL){
                             if ( fread(buf, 1, sizeof(buf), pdbFile) == 0 ) {
@@ -2399,6 +2421,7 @@ CosaDmlDcSetFactoryReset
                             }
                            fclose(pdbFile);
                         }
+#endif
                         dbValue++;
                         pdbFile = fopen(FACTORY_RESET_COUNT_FILE, "w+");
                         if(pdbFile != NULL){
@@ -2567,6 +2590,9 @@ CosaDmlDcSetFactoryReset
 		
 		Utopia_Free(&utctx,1);
 		//system("reboot");i
+#if defined (_COSA_QCA_ARM_)
+        system("reboot");
+#endif
 		//Set LastRebootReason before device bootup
 		CcspTraceWarning(("FactoryReset:%s Set LastRebootReason to factory-reset ...\n",__FUNCTION__));
 		if ((syscfg_set_commit(NULL, "X_RDKCENTRAL-COM_LastRebootReason", "factory-reset") != 0))
@@ -3097,6 +3123,101 @@ void  Set_IPMode_AllInterfaces(ULONG value)
 	    }
         }
     }
+}
+#endif
+
+#if defined (_COSA_QCA_ARM_)
+ANSC_STATUS
+CosaGetMcProxyValues
+    (
+        ANSC_HANDLE                 hContext,
+        PCOSA_DML_MCPROXY           pEntry
+    )
+{
+    char buf1[128] = {0};
+    errno_t rc = -1;
+    memset(buf1, 0, sizeof(buf1));
+
+    syscfg_get( NULL, "mcproxy.disabled", buf1, sizeof(buf1));
+    pEntry->bEnabled = !atoi(buf1);
+
+    syscfg_get( NULL, "mcproxy.name", buf1, sizeof(buf1));
+    rc = snprintf(pEntry->Name, sizeof(pEntry->Name), "%s", buf1);
+    if(rc < EOK)
+    {
+        ERR_CHK(rc);
+    }
+
+    syscfg_get( NULL, "mcproxy.upstream", buf1, sizeof(buf1));
+    rc = snprintf(pEntry->Upstream, sizeof(pEntry->Upstream), "%s", buf1);
+    if(rc < EOK)
+    {
+        ERR_CHK(rc);
+    }
+
+    syscfg_get( NULL, "mcproxy.downstream", buf1, sizeof(buf1));
+    rc  = snprintf(pEntry->Downstream, sizeof(pEntry->Downstream), "%s", buf1);
+    if(rc < EOK)
+    {
+        ERR_CHK(rc);
+    }
+
+    syscfg_get( NULL, "mcproxy.protocol", buf1, sizeof(buf1));
+    if (!_ansc_strcmp ( buf1 , "IGMPv3"))
+        rc = snprintf(pEntry->bProtocol, sizeof(pEntry->bProtocol), "IPv4");
+
+    else if (!_ansc_strcmp (buf1 , "MLDv2"))
+        rc = snprintf(pEntry->bProtocol, sizeof(pEntry->bProtocol), "IPv6");
+    if(rc < EOK)
+    {
+        ERR_CHK(rc);
+    }
+    return ANSC_STATUS_SUCCESS;
+}
+
+ANSC_STATUS
+Cosa_Set_McProxy
+    (
+        ANSC_HANDLE                 hContext,
+        PCOSA_DML_MCPROXY           pEntry
+    )
+{
+    char buf[20];
+    char downstream_buf[20];
+    AnscTraceFlow(("<HL>%s start\n",__func__));
+    vsystem("systemctl start mcproxy.service");
+    sleep(1);
+
+    snprintf(buf, sizeof(buf), "%d", !pEntry->bEnabled);
+    syscfg_set_commit(NULL, "mcproxy.disabled",buf);
+
+    snprintf(buf, sizeof(buf), "%s", pEntry->Name);
+    syscfg_set_commit(NULL, "mcproxy.name", buf);
+
+    snprintf(buf, sizeof(buf), "%s", pEntry->Upstream);
+    syscfg_set_commit(NULL, "mcproxy.upstream", buf);
+
+    snprintf(buf, sizeof(buf), "%s", pEntry->Downstream);
+    syscfg_set_commit(NULL, "mcproxy.downstream", buf);
+
+    if (!_ansc_strcmp ( pEntry->bProtocol , "IPv6"))
+    {
+        syscfg_set_commit(NULL, "mcproxy.protocol", "MLDv2");
+
+        snprintf(buf, sizeof(buf), "%s", pEntry->Ipv6_erouterIP);
+        snprintf(downstream_buf, sizeof(downstream_buf), "%s", pEntry->Downstream);
+        vsystem("ip addr add %s dev %s", buf, downstream_buf);
+    }
+    if (!_ansc_strcmp ( pEntry->bProtocol , "IPv4"))
+        syscfg_set_commit(NULL, "mcproxy.protocol", "IGMPv3");
+
+    if (pEntry->bEnabled) {
+        vsystem("systemctl restart mcproxy.service");
+    } else {
+        vsystem("systemctl stop mcproxy.service");
+    }
+
+    return ANSC_STATUS_SUCCESS;
 }
 #endif
 

--- a/source/TR-181/include/cosa_x_cisco_com_devicecontrol_apis.h
+++ b/source/TR-181/include/cosa_x_cisco_com_devicecontrol_apis.h
@@ -156,6 +156,33 @@ _COSA_DML_LAN_MANAGEMENT
 }
 COSA_DML_LAN_MANAGEMENT, *PCOSA_DML_LAN_MANAGEMENT;
 
+#if defined (_COSA_QCA_ARM_)
+typedef struct
+_COSA_DML_MCPROXY
+{
+ BOOLEAN bEnabled;
+ char Name[COSA_DML_IF_NAME_LENGTH];
+ char Upstream[COSA_DML_IF_NAME_LENGTH];
+ char Downstream[COSA_DML_IF_NAME_LENGTH];
+ char bProtocol[COSA_DML_IF_NAME_LENGTH];
+ char Ipv6_erouterIP[COSA_DML_IF_NAME_LENGTH];
+ BOOLEAN ApplySetting;
+}
+COSA_DML_MCPROXY, *PCOSA_DML_MCPROXY;
+
+typedef struct
+_COSA_DML_APPLYSETTING
+{
+ BOOLEAN apply_bEnabled;
+ char apply_Name[COSA_DML_IF_NAME_LENGTH];
+ char apply_Upstream[COSA_DML_IF_NAME_LENGTH];
+ char apply_Downstream[COSA_DML_IF_NAME_LENGTH];
+ char apply_bProtocol[COSA_DML_IF_NAME_LENGTH];
+ char apply_Ipv6_erouterIP[COSA_DML_IF_NAME_LENGTH];
+ BOOLEAN apply_ApplySetting;
+}
+COSA_DML_APPLYSETTING, *PCOSA_DML_APPLYSETTING;
+#endif
 typedef struct
 _COSA_NOTIFY_WIFI
 {
@@ -2425,5 +2452,19 @@ CosaDmlDcSetWebUITimeout
         ANSC_HANDLE                 hContext,
         ULONG                       value
     );
+#if defined (_COSA_QCA_ARM_)
+ANSC_STATUS
+Cosa_Set_McProxy
+ (
+ANSC_HANDLE                 hContext,
+ PCOSA_DML_MCPROXY          pEntry
+ );
 
+ANSC_STATUS
+CosaGetMcProxyValues
+ (
+ ANSC_HANDLE                 hContext,
+ PCOSA_DML_MCPROXY          pEntry
+ );
+#endif
 #endif

--- a/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c
@@ -1799,6 +1799,503 @@ X_CISCO_COM_DeviceControl_Rollback
 
     return 0;
 }
+#if defined (_COSA_QCA_ARM_)
+/***********************************************************************
+
+ APIs for Object:
+
+    DeviceControl.X_CISCO_COM_DeviceControl.
+
+    *  X_IPQ_McProxy_GetEntryCount
+    *  X_IPQ_McProxy_GetEntry
+    *  X_IPQ_McProxy_GetParamBoolValue
+    *  X_IPQ_McProxy_GetParamStringValue
+    *  X_IPQ_McProxy_SetParamBoolValue
+    *  X_IPQ_McProxy_SetParamStringValue
+    *  X_IPQ_McProxy_Validate
+    *  X_IPQ_McProxy_Commit
+
+***********************************************************************/
+
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        ULONG
+        X_IPQ_McProxy_GetEntryCount
+            (
+                ANSC_HANDLE                 hInsContext
+            );
+
+    description:
+
+        This function is called to retrieve the count of the table.
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+    return:     The count of the table
+
+**********************************************************************/
+COSA_DML_APPLYSETTING        g_tmp_McProxy;
+
+ULONG
+X_IPQ_McProxy_GetEntryCount
+    (
+        ANSC_HANDLE                 hInsContext
+    )
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+    return 1;
+}
+
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        ANSC_HANDLE
+        X_IPQ_McProxy_GetEntry
+            (
+                ANSC_HANDLE                 hInsContext,
+                ULONG                       nIndex,
+                ULONG*                      pInsNumber
+            );
+
+    description:
+
+        This function is called to retrieve the entry specified by the index.
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                ULONG                       nIndex,
+                The index of this entry;
+
+                ULONG*                      pInsNumber
+                The output instance number;
+
+    return:     The handle to identify the entry
+
+**********************************************************************/
+ANSC_HANDLE
+X_IPQ_McProxy_GetEntry
+    (
+        ANSC_HANDLE                 hInsContext,
+        ULONG                       nIndex,
+        ULONG*                      pInsNumber
+    )
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+    PCOSA_DML_MCPROXY pEntry  = (PCOSA_DML_MCPROXY)AnscAllocateMemory(sizeof(COSA_DML_MCPROXY));
+    memset(pEntry, 0, sizeof(COSA_DML_MCPROXY));
+
+    *pInsNumber = 1;
+    CosaGetMcProxyValues(NULL, (PCOSA_DML_MCPROXY)pEntry);
+    memcpy(&g_tmp_McProxy, pEntry, sizeof(COSA_DML_MCPROXY));
+    return pEntry; /* return the handle*/
+}
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        X_IPQ_McProxy_GetParamBoolValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                BOOL*                       pBool
+            );
+
+    description:
+
+        This function is called to retrieve Boolean parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                BOOL*                       pBool
+                The buffer of returned boolean value;
+
+    return:     TRUE if succeeded.
+
+ **********************************************************************/
+
+BOOL
+X_IPQ_McProxy_GetParamBoolValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        BOOL*                       pBool
+    )
+{
+    PCOSA_DML_MCPROXY        pMcProxy    = (PCOSA_DML_MCPROXY)hInsContext;
+    if (strcmp(ParamName, "Enable") == 0)
+    {
+        *pBool = pMcProxy->bEnabled;
+         return TRUE;
+    }
+    if (strcmp(ParamName, "ApplySettings") == 0)
+    {
+        *pBool = pMcProxy->ApplySetting;
+        return TRUE;
+    }
+    return FALSE;
+}
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        X_IPQ_McProxy_GetParamStringValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                char*                       pValue,
+                ULONG*                      pUlSize
+            );
+
+    description:
+
+        This function is called to retrieve String  parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                char*                       pValue
+                The buffer of returned string  value;
+
+    return:     TRUE if succeeded.
+
+ **********************************************************************/
+
+BOOL
+X_IPQ_McProxy_GetParamStringValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        char*                       pValue,
+        ULONG*                      pUlSize
+    )
+{
+    PCOSA_DML_MCPROXY        pMcProxy    = (PCOSA_DML_MCPROXY)hInsContext;
+    errno_t                  rc          = -1;
+    if (strcmp(ParamName, "Protocol") == 0)
+    {
+        if ( AnscSizeOfString(pMcProxy->bProtocol) < *pUlSize)
+        rc = strcpy_s(pValue, *pUlSize, pMcProxy->bProtocol);
+        ERR_CHK(rc);
+        return 0;
+    }
+    if (strcmp(ParamName, "Upstream") == 0)
+    {
+        if ( AnscSizeOfString(pMcProxy->Upstream) < *pUlSize)
+        rc = strcpy_s(pValue, *pUlSize, pMcProxy->Upstream);
+        ERR_CHK(rc);
+        return 0;
+    }
+    if (strcmp(ParamName, "Downstream") == 0)
+    {
+        if ( AnscSizeOfString(pMcProxy->Downstream) < *pUlSize)
+        rc = strcpy_s(pValue, *pUlSize, pMcProxy->Downstream);
+        ERR_CHK(rc);
+        return 0;
+    }
+    if (strcmp(ParamName, "Name") == 0)
+    {
+        if ( AnscSizeOfString(pMcProxy->Name) < *pUlSize)
+        rc = strcpy_s(pValue, *pUlSize, pMcProxy->Name);
+        ERR_CHK(rc);
+        return 0;
+
+    }
+    if (strcmp(ParamName, "X_IPQ_McProxy_IPv6_brlan_IP") == 0)
+    {
+        if ( AnscSizeOfString(pMcProxy->Ipv6_erouterIP) < *pUlSize)
+        rc = strcpy_s(pValue, *pUlSize, pMcProxy->Ipv6_erouterIP);
+        ERR_CHK(rc);
+        return 0;
+    }
+    return FALSE;
+}
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        X_IPQ_McProxy_SetParamBoolValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                BOOL                        bValue
+            );
+
+    description:
+
+        This function is called to set Boolean parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                BOOL                        bValue
+                The updated boolean parameter value
+
+    return:     TRUE if succeeded.
+
+ **********************************************************************/
+
+
+BOOL
+X_IPQ_McProxy_SetParamBoolValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        BOOL                        bValue
+    )
+{
+    PCOSA_DML_MCPROXY       pMcProxy  = (PCOSA_DML_MCPROXY)hInsContext;
+    errno_t                 rc        = -1;
+
+    if (strcmp(ParamName, "Enable") == 0)
+    {
+        g_tmp_McProxy.apply_bEnabled  = bValue;
+        g_tmp_McProxy.apply_ApplySetting = pMcProxy->ApplySetting = FALSE;
+        return TRUE;
+    }
+    if (strcmp(ParamName, "ApplySettings") == 0)
+    {
+        g_tmp_McProxy.apply_ApplySetting = bValue;
+
+        if ( g_tmp_McProxy.apply_ApplySetting)
+        {
+            pMcProxy->bEnabled = g_tmp_McProxy.apply_bEnabled;
+            pMcProxy->ApplySetting =  g_tmp_McProxy.apply_ApplySetting;
+            rc = STRCPY_S_NOCLOBBER((char *)pMcProxy->bProtocol, sizeof(pMcProxy->bProtocol), g_tmp_McProxy.apply_bProtocol);
+            if(rc != EOK)
+            {
+                ERR_CHK(rc);
+                return FALSE;
+            }
+            rc = STRCPY_S_NOCLOBBER((char *)pMcProxy->Name, sizeof(pMcProxy->Name), g_tmp_McProxy.apply_Name);
+            if(rc != EOK)
+            {
+                ERR_CHK(rc);
+                return FALSE;
+            }
+            rc = STRCPY_S_NOCLOBBER((char *)pMcProxy->Upstream, sizeof(pMcProxy->Upstream), g_tmp_McProxy.apply_Upstream);
+            if(rc != EOK)
+            {
+                ERR_CHK(rc);
+                return FALSE;
+            }
+            rc = STRCPY_S_NOCLOBBER((char *)pMcProxy->Downstream, sizeof(pMcProxy->Downstream), g_tmp_McProxy.apply_Downstream);
+            if(rc != EOK)
+            {
+                ERR_CHK(rc);
+                return FALSE;
+            }
+            rc = STRCPY_S_NOCLOBBER((char *)pMcProxy->Ipv6_erouterIP, sizeof(pMcProxy->Ipv6_erouterIP), g_tmp_McProxy.apply_Ipv6_erouterIP);
+            if(rc != EOK)
+            {
+                ERR_CHK(rc);
+                return FALSE;
+            }
+
+        }
+        else
+        {
+            //Set only apply setting parameter
+            pMcProxy->ApplySetting = g_tmp_McProxy.apply_ApplySetting ;
+        }
+        return TRUE;
+
+    }
+
+    return FALSE;
+}
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        X_IPQ_McProxy_SetParamstringValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                char*                       pString
+            );
+
+    description:
+
+        This function is called to set Boolean parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                char*                       pString
+                The updated string parameter value
+    return:     TRUE if succeeded.
+
+ **********************************************************************/
+
+BOOL
+X_IPQ_McProxy_SetParamStringValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        char*                       pString
+    )
+{
+    PCOSA_DML_MCPROXY        pMcProxy  = (PCOSA_DML_MCPROXY)hInsContext;
+    ANSC_STATUS              retStatus = ANSC_STATUS_SUCCESS;
+    errno_t                  rc        = -1;
+    int                      ind       = -1;
+
+    if((ParamName == NULL) || (pString == NULL))
+        return FALSE;
+    /* check the parameter name and set the corresponding value */
+
+    rc = strcmp_s("Protocol", strlen("Protocol"), ParamName, &ind);
+    ERR_CHK(rc);
+    if((rc == EOK) && (!ind))
+    {
+	if ((_ansc_strcmp ( pString , "MLDv2")) &&
+            (_ansc_strcmp ( pString , "IGMPv3")))
+    	{
+            return FALSE;
+    	}
+        rc = STRCPY_S_NOCLOBBER((char *)g_tmp_McProxy.apply_bProtocol, sizeof(g_tmp_McProxy.apply_bProtocol), pString);
+        if(rc != EOK)
+        {
+            ERR_CHK(rc);
+            return FALSE;
+        }
+        g_tmp_McProxy.apply_ApplySetting = pMcProxy->ApplySetting = FALSE;
+        return TRUE;
+    }
+    rc = strcmp_s("Upstream", strlen("Upstream"), ParamName, &ind);
+    ERR_CHK(rc);
+    if((rc == EOK) && (!ind))
+    {
+        rc = STRCPY_S_NOCLOBBER((char *)g_tmp_McProxy.apply_Upstream, sizeof(g_tmp_McProxy.apply_Upstream), pString);
+        if(rc != EOK)
+        {
+            ERR_CHK(rc);
+            return FALSE;
+        }
+        g_tmp_McProxy.apply_ApplySetting = pMcProxy->ApplySetting = FALSE;
+        return TRUE;
+    }
+    rc = strcmp_s("Downstream", strlen("Downstream"), ParamName, &ind);
+    ERR_CHK(rc);
+    if((rc == EOK) && (!ind))
+    {
+        rc = STRCPY_S_NOCLOBBER((char *)g_tmp_McProxy.apply_Downstream, sizeof(g_tmp_McProxy.apply_Downstream), pString);
+        if(rc != EOK)
+        {
+            ERR_CHK(rc);
+            return FALSE;
+        }
+        g_tmp_McProxy.apply_ApplySetting = pMcProxy->ApplySetting = FALSE;
+        return TRUE;
+    }
+    rc = strcmp_s("Name", strlen("Name"), ParamName, &ind);
+    ERR_CHK(rc);
+    if((rc == EOK) && (!ind))
+    {
+        rc = STRCPY_S_NOCLOBBER((char *)g_tmp_McProxy.apply_Name, sizeof(g_tmp_McProxy.apply_Name), pString);
+        if(rc != EOK)
+        {
+            ERR_CHK(rc);
+            return FALSE;
+        }
+        g_tmp_McProxy.apply_ApplySetting = pMcProxy->ApplySetting = FALSE;
+        return TRUE;
+    }
+    rc = strcmp_s("X_IPQ_McProxy_IPv6_brlan_IP", strlen("X_IPQ_McProxy_IPv6_brlan_IP"), ParamName, &ind);
+    ERR_CHK(rc);
+    if((rc == EOK) && (!ind))
+    {
+        rc = STRCPY_S_NOCLOBBER((char *)g_tmp_McProxy.apply_Ipv6_erouterIP, sizeof(g_tmp_McProxy.apply_Ipv6_erouterIP), pString);
+        if(rc != EOK)
+        {
+            ERR_CHK(rc);
+            return FALSE;
+        }
+        g_tmp_McProxy.apply_ApplySetting = pMcProxy->ApplySetting = FALSE;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+ULONG
+X_IPQ_McProxy_Validate
+    (
+        ANSC_HANDLE                 hInsContext
+    )
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+    return TRUE;
+}
+
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+        ULONG
+        X_IPQ_McProxy_Commit
+            (
+                ANSC_HANDLE                 hInsContext
+            );
+
+    description:
+
+    This function is called to finally commit all the update.
+
+    argument:    ANSC_HANDLE hInsContext,
+    The instance handle;
+
+    return:     The status of the operation.
+ **********************************************************************/
+ULONG
+X_IPQ_McProxy_Commit
+    (
+        ANSC_HANDLE                 hInsContext
+    )
+{
+    PCOSA_DML_MCPROXY        pMcProxy    = (PCOSA_DML_MCPROXY)hInsContext;
+
+    if (pMcProxy->ApplySetting == TRUE)
+        Cosa_Set_McProxy(NULL, (PCOSA_DML_MCPROXY)pMcProxy);
+    else
+        return  ANSC_STATUS_SUCCESS;
+    return 0;
+}
+#endif
 
 ULONG
 LanMngm_GetEntryCount

--- a/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.h
+++ b/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.h
@@ -312,7 +312,65 @@ X_CISCO_COM_DeviceControl_Rollback
     (
         ANSC_HANDLE                 hInsContext
     );
+#if defined (_COSA_QCA_ARM_)
+ULONG
+X_IPQ_McProxy_GetEntryCount
+    (
+        ANSC_HANDLE                 hInsContext
+    );
 
+ANSC_HANDLE
+X_IPQ_McProxy_GetEntry
+    (
+        ANSC_HANDLE                 hInsContext,
+        ULONG                       nIndex,
+        ULONG*                      pInsNumber
+    );
+
+BOOL
+X_IPQ_McProxy_GetParamBoolValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        BOOL*                       pBool
+    );
+
+BOOL
+X_IPQ_McProxy_GetParamStringValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        char*                       pValue,
+        ULONG*                      pUlSize
+    );
+BOOL
+X_IPQ_McProxy_SetParamBoolValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        BOOL                        bValue
+    );
+
+BOOL
+X_IPQ_McProxy_SetParamStringValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        char*                       pString
+    );
+
+ULONG
+X_IPQ_McProxy_Validate
+    (
+        ANSC_HANDLE                 hInsContext
+    );
+
+ULONG
+X_IPQ_McProxy_Commit
+    (
+        ANSC_HANDLE                 hInsContext
+    );
+#endif
 /**
  * @brief Gets the number of LAN management entries in Device.X_CISCO_COM_DeviceControl.LanManagementEntry table.
  *


### PR DESCRIPTION
- Implemented a new data model X_IPQ_McProxy to support the MC Proxy feature for IPQ-based devices.
- Fixed an issue where the device was not rebooting when a reboot was triggered via ACS.
- Added support for tracking and reporting the factory reset count on IPQ devices.