### PR TITLE
RDKB-63098: [ONESTACK]-Handle IPv6 delegation for business  vs residential Partner ID as part of single build

### DIFF
--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -22223,7 +22223,7 @@ MAPT_DeviceInfo_SetParamBoolValue
 #if defined(_ONESTACK_PRODUCT_REQ_)
 	if (bValue)
 	{
-            if (!isFeatureSupportedInCurrentMode(FEATURE_MAPT))
+            if (!isFeatureSupportedInCurrentMode(FEATURE_MAPT_MODE))
             {
                 CcspTraceError(("MAP-T enable rejected, unsupported mode\n"));
                 t2_event_d("MAP-T_NotSupported", 1);


### PR DESCRIPTION


Reason for change: Prefix delegation handling
Test Procedure:
  - Build OneStack Image
  - In Business-mode, Check dibbler server is started and server.conf has prefix-delegation class
  - In Residential-mode,  check whether device behaves as a non-CBR device Risks: None
Priority: P1