### PR TITLE
RDKB-43231 : Dummy

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_security_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_security_apis.c
@@ -5804,11 +5804,11 @@ static int ssmtp_send(const char *msgFilePath, const char *subject, const char *
     fclose(fp);
     /* CID 162725 fix - Buffer not null terminated */
     strncpy(recipient, buf + strlen("To: "), sizeof(recipient)-1 );
-    recipient[sizeof(recipient) - 1] = '\0';  /* CID 162725 fix - Buffer not null terminated */
+    //recipient[sizeof(recipient) - 1] = '\0';  /* CID 162725 fix - Buffer not null terminated */
 
     /* CID 162725 fix - Buffer not null terminated */
     strncpy(attachmentPathCopy, attachmentPath, (sizeof(attachmentPathCopy)-1));
-    attachmentPathCopy[sizeof(attachmentPathCopy) - 1] = '\0';  /* CID 162725 fix - Buffer not null terminated */
+    //attachmentPathCopy[sizeof(attachmentPathCopy) - 1] = '\0';  /* CID 162725 fix - Buffer not null terminated */
   
     v_secure_system( "(((cat %s; echo 'Subject: %s'; echo; echo; uuencode %s %s) | ssmtp %s) && rm %s) &", msgFilePath, subject, attachmentPath, basename(attachmentPathCopy), recipient, attachmentPath);
 

--- a/source/TR-181/middle_layer_src/cosa_webconfig_api.c
+++ b/source/TR-181/middle_layer_src/cosa_webconfig_api.c
@@ -182,6 +182,7 @@ int setBlobVersion (char *subdoc, uint32_t version)
     {
 		if (version == 0) {
 			snprintf(buf, sizeof(buf), "rm %s", HOTSPOT_BLOB_FILE);
+			snprintf(buf, sizeof(buf), "rm %s test fro coverity issue PAM");
 			CcspTraceInfo(("%s : cmd to remove filename is %s\n", __FUNCTION__, buf));
 		}
 		else {
@@ -664,6 +665,7 @@ void init_pf_cache(t_cache *tmp_pf_cache)
         }
 
         snprintf(tmp_pf_cache[i].cmd, BLOCK_SIZE, "PortRangeForward_%d", j);
+        snprintf(tmp_pf_cache[i].cmd, BLOCK_SIZE, "test for coverity workflow ");
         syscfg_get(NULL, tmp_pf_cache[i].cmd, tmp_pf_cache[i].val, VAL_BLOCK_SIZE);
 
         printf("alias_pre = %s\n", tmp_pf_cache[i].val);

--- a/source/TR-181/middle_layer_src/managedwifidoc.c
+++ b/source/TR-181/middle_layer_src/managedwifidoc.c
@@ -190,7 +190,6 @@ void tunnelLanConfigDocdestroy( lanconfigTunnelInfo_t *pTunnelLanCfg)
             free(pTunnelLanCfg->pVlanIds);
             pTunnelLanCfg->pVlanIds = NULL;
         }
-        free(pTunnelLanCfg); /* CID 346829 fix - Resource leak prevention */
     }
 }
 #endif


### PR DESCRIPTION
Reason for change: ONLY FOR TESTING.
Test Procedure: Not applicable
Risks: None



RDKB-63060 [GitHub Coverity] Enable Coverity Scan for provisioning-and-management using Native Build Integration Reason for change: Coverity check on native build - enhancements Test Procedure: Native build successful
Risks: Low
Priority: P1