### PR TITLE
Reason for change: ONLY FOR TESTING.

### DIFF
--- a/source/TR-181/middle_layer_src/cosa_webconfig_api.c
+++ b/source/TR-181/middle_layer_src/cosa_webconfig_api.c
@@ -182,6 +182,7 @@ int setBlobVersion (char *subdoc, uint32_t version)
     {
 		if (version == 0) {
 			snprintf(buf, sizeof(buf), "rm %s", HOTSPOT_BLOB_FILE);
+			snprintf(buf, sizeof(buf), "rm %s dummy for coverity");
 			CcspTraceInfo(("%s : cmd to remove filename is %s\n", __FUNCTION__, buf));
 		}
 		else {
@@ -842,10 +843,11 @@ void freeResources_PortForwarding(void *arg)
         portmappingdoc_destroy( rpm );  
         rpm = NULL;
     }
-
+#if 0 //dummy coverity
     if ( blob_exec_data != NULL )
     {
         free(blob_exec_data);
         blob_exec_data = NULL ;
     }
+#else
 }


### PR DESCRIPTION
Test Procedure: Not applicable
Risks: None

RDKB-63060 [GitHub Coverity] Enable Coverity Scan for provisioning-and-management using Native Build Integration Reason for change: Coverity check on native build - enhancements Test Procedure: Native build successful
Risks: Low
Priority: P1