### PR TITLE
RDKB-63886: Ignite - XLE IPv6 Default Route Is Not Deleted 

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
@@ -11622,9 +11622,6 @@ void Switch_ipv6_mode(char *ifname, int length)
 		delRemoteWanIpv6Route();
 		CcspTraceInfo(("%s-%d : Deleted RemoteWAN Default Route \n",__FUNCTION__, __LINE__));
 	    }
-#endif
-
-#if defined(WAN_MANAGER_UNIFICATION_ENABLED)
             addRemoteWanIpv6Route();
 #endif
         }

--- a/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
@@ -11614,6 +11614,17 @@ void Switch_ipv6_mode(char *ifname, int length)
             SwitchToULAIpv6(); //Secondary Wan
             CcspTraceWarning(("%s: Switched to ULA IPv6\n", __FUNCTION__));
 #if defined(WAN_MANAGER_UNIFICATION_ENABLED)
+	    char tmpBuf[32] ={0};
+	    /* Switching from Secondary Wan(brRWAN) to Secondary Wan(brww0) */
+	    commonSyseventGet("remotewan_routeset", tmpBuf, sizeof(tmpBuf));
+	    if (strcmp(tmpBuf,"true") == 0 )
+	    {
+		delRemoteWanIpv6Route();
+		CcspTraceInfo(("%s-%d : Deleted RemoteWAN Default Route \n",__FUNCTION__, __LINE__));
+	    }
+#endif
+
+#if defined(WAN_MANAGER_UNIFICATION_ENABLED)
             addRemoteWanIpv6Route();
 #endif
         }

--- a/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
@@ -11614,7 +11614,7 @@ void Switch_ipv6_mode(char *ifname, int length)
             CcspTraceWarning(("%s: Switched to ULA IPv6\n", __FUNCTION__));
 #if defined(WAN_MANAGER_UNIFICATION_ENABLED)
 	        char tmpBuf[32] ={0};
-	        /* Switching from Secondary Wan(brRWAN) to Secondary Wan(brww0) */
+	        /* Update RemoteWAN IPv6 routing for a secondary WAN interface transition. */
 	        commonSyseventGet("remotewan_routeset", tmpBuf, sizeof(tmpBuf));
 	        if (strcmp(tmpBuf,"true") == 0 )
 	        {

--- a/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_dhcpv6_apis.c
@@ -11590,7 +11590,7 @@ void Switch_ipv6_mode(char *ifname, int length)
         char hotspot_wan_ifname[32] = {0};
         getMeshWanIfName(mesh_wan_ifname,sizeof(mesh_wan_ifname));
         getHotSpotWanIfName(hotspot_wan_ifname,sizeof(hotspot_wan_ifname));
-	CcspTraceWarning((" %s :MESH WAN IFNAME is (%s), WAN MANAGER IFNAME is (%s)\n", __FUNCTION__,ifname, hotspot_wan_ifname));
+	    CcspTraceWarning((" %s :MESH WAN IFNAME is (%s), WAN MANAGER IFNAME is (%s)\n", __FUNCTION__,ifname, hotspot_wan_ifname));
         if((strncmp(ifname, mesh_wan_ifname,length ) == 0) || (strncmp(ifname, hotspot_wan_ifname,length ) == 0))
 #else
         char default_wan_ifname[64];
@@ -11600,7 +11600,7 @@ void Switch_ipv6_mode(char *ifname, int length)
 #endif
         {
 #ifdef MONITOR_IPV6_NETLINK
-	    pthread_t MonitorIpv6_tid;
+            pthread_t MonitorIpv6_tid;
             char *hotspotIfname_copy = strdup(hotspot_wan_ifname); // pass to thread
 
             if (pthread_create(&MonitorIpv6_tid, NULL, monitor_ipv6_assignments, (void *)hotspotIfname_copy) != 0) {
@@ -11610,18 +11610,17 @@ void Switch_ipv6_mode(char *ifname, int length)
                 pthread_detach(MonitorIpv6_tid); // thread will run independently
             }
 #endif
-
             SwitchToULAIpv6(); //Secondary Wan
             CcspTraceWarning(("%s: Switched to ULA IPv6\n", __FUNCTION__));
 #if defined(WAN_MANAGER_UNIFICATION_ENABLED)
-	    char tmpBuf[32] ={0};
-	    /* Switching from Secondary Wan(brRWAN) to Secondary Wan(brww0) */
-	    commonSyseventGet("remotewan_routeset", tmpBuf, sizeof(tmpBuf));
-	    if (strcmp(tmpBuf,"true") == 0 )
-	    {
-		delRemoteWanIpv6Route();
-		CcspTraceInfo(("%s-%d : Deleted RemoteWAN Default Route \n",__FUNCTION__, __LINE__));
-	    }
+	        char tmpBuf[32] ={0};
+	        /* Switching from Secondary Wan(brRWAN) to Secondary Wan(brww0) */
+	        commonSyseventGet("remotewan_routeset", tmpBuf, sizeof(tmpBuf));
+	        if (strcmp(tmpBuf,"true") == 0 )
+	        {
+		        delRemoteWanIpv6Route();
+		        CcspTraceInfo(("%s-%d : Deleted RemoteWAN Default Route \n",__FUNCTION__, __LINE__));
+	        }
             addRemoteWanIpv6Route();
 #endif
         }


### PR DESCRIPTION
Reason for change: When changing from ULA to ULA, remote WAN default routes are not deleted Test Procedure:
  - Bring up the CPE with the Sprint build.
  - Bring up the XLE and ensure that the XLE is connected to the XB.
  - Disconnect the Primary WAN from the XB. The WAN connection should move to the XLE.
  - After some time, switch off the XLE.
  - Bring up a neighbor device.
  - The XB connects to the Hotspot WAN.
  - Validate the IPv6 default route.

Risks: None
Priority: P1