### PR TITLE
RDKB-64189: Enable ZRAM to optimize and reduce RDKB memory usage

### DIFF
--- a/config-arm/TR181-USGv2.XML
+++ b/config-arm/TR181-USGv2.XML
@@ -2468,6 +2468,68 @@
 			     </object>
                             </objects>
                         </object>
+
+                        <object>
+                            <name>MEMSWAP</name>
+                            <objectType>object</objectType>
+                            <functions>
+                                <func_GetParamBoolValue>MEMSWAP_GetParamBoolValue</func_GetParamBoolValue>
+                                <func_SetParamBoolValue>MEMSWAP_SetParamBoolValue</func_SetParamBoolValue>
+                                <func_GetParamUlongValue>MEMSWAP_GetParamUlongValue</func_GetParamUlongValue>
+                                <func_SetParamUlongValue>MEMSWAP_SetParamUlongValue</func_SetParamUlongValue>
+                            </functions>
+                            <parameters>
+                                <parameter>
+                                    <name>Enable</name>
+                                    <type>boolean</type>
+                                    <syntax>bool</syntax>
+                                    <writable>true</writable>
+                                </parameter>
+                                <parameter>
+                                    <name>DiskSize</name>
+                                    <type>unsignedInt</type>
+                                    <syntax>uint32</syntax>
+                                    <writable>true</writable>
+                                </parameter>
+                                <parameter>
+                                    <name>StatsInterval</name>
+                                    <type>unsignedInt</type>
+                                    <syntax>uint32</syntax>
+                                    <writable>true</writable>
+                                </parameter>
+                            </parameters>
+                            <objects>
+                                <object>
+                                    <name>Tunables</name>
+                                    <objectType>object</objectType>
+                                    <functions>
+                                        <func_GetParamUlongValue>Tunables_GetParamUlongValue</func_GetParamUlongValue>
+                                        <func_SetParamUlongValue>Tunables_SetParamUlongValue</func_SetParamUlongValue>
+                                    </functions>
+                                    <parameters>
+                                        <parameter>
+                                            <name>Swappiness</name>
+                                            <type>unsignedInt</type>
+                                            <syntax>uint32</syntax>
+                                            <writable>true</writable>
+                                        </parameter>
+                                        <parameter>
+                                            <name>WatermarkScaleFactor</name>
+                                            <type>unsignedInt</type>
+                                            <syntax>uint32</syntax>
+                                            <writable>true</writable>
+                                        </parameter>
+                                        <parameter>
+                                            <name>PageCluster</name>
+                                            <type>unsignedInt</type>
+                                            <syntax>uint32</syntax>
+                                            <writable>true</writable>
+                                        </parameter>
+                                    </parameters>
+                                </object>
+                            </objects>
+            </object>
+
 			<object>
 			  <name>SoftwareProcessManager</name>
 			  <objectType>object</objectType>

--- a/config-arm/TR181-USGv2.XML
+++ b/config-arm/TR181-USGv2.XML
@@ -2791,32 +2791,6 @@
 			</parameters>   
 
 		</object>
-
-                <object>
-                        <name>MEMSWAP</name>
-
-                        <objectType>object</objectType>
-
-                        <functions>
-                                <func_GetParamBoolValue>MEMSWAP_GetParamBoolValue</func_GetParamBoolValue>
-                                <func_SetParamBoolValue>MEMSWAP_SetParamBoolValue</func_SetParamBoolValue>
-                        </functions>
-
-                        <parameters>
-                                <parameter>
-
-                                        <name>Enable</name>
-
-                                        <type>boolean</type>
-
-                                        <syntax>bool</syntax>
-
-                                        <writable>true</writable>
-
-                                </parameter>
-                         </parameters>
-                </object>
-
 	<object>
         <name>SyndicationFlowControl</name>
         <objectType>object</objectType>

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -25554,14 +25554,14 @@ MEMSWAP_GetParamBoolValue
     if (strcmp(ParamName, "Enable") == 0)
     {
         char value[8] = {0};
-        if( syscfg_get(NULL, "MemorySwapEnable", value, sizeof(value)) == 0 )
+        if(syscfg_get(NULL, "MemorySwapEnable", value, sizeof(value)) == 0)
         {
             *pBool = (strcmp(value, "true") == 0) ? TRUE : FALSE;
             return TRUE;
         }
         else
         {
-            CcspTraceError(("syscfg_get failed for MemorySwapEnable\n"));
+            CcspTraceError(("%s: syscfg_get failed for MemorySwapEnable\n", __FUNCTION__));
             return FALSE;
         }
     }
@@ -25616,7 +25616,7 @@ MEMSWAP_SetParamBoolValue
     {
         if (syscfg_set_commit(NULL, "MemorySwapEnable", bValue ? "true" : "false") != 0)
         {
-            CcspTraceError(("syscfg_set failed for MemorySwapEnable\n"));
+            CcspTraceError(("%s: syscfg_set failed for MemorySwapEnable\n", __FUNCTION__));
             return FALSE;
         }
         return TRUE;
@@ -25667,26 +25667,27 @@ MEMSWAP_GetParamUlongValue
     if (strcmp(ParamName, "DiskSize") == 0)
     {
         char value[8] = {0};
-        if( syscfg_get(NULL, "MemorySwapDiskSizeMB", value, sizeof(value)) == 0 )
+        if(syscfg_get(NULL, "MemorySwapDiskSizeMB", value, sizeof(value)) == 0)
         {
             *puLong = atol(value);
             return TRUE;
         }
         else
         {
-            CcspTraceError(("syscfg_get failed for MemorySwapDiskSizeMB\n"));
+            CcspTraceError(("%s: syscfg_get failed for MemorySwapDiskSizeMB\n", __FUNCTION__));
             return FALSE;
         }
     } else if (strcmp(ParamName, "StatsInterval") == 0)
     {
         char value[8] = {0};
-        if( syscfg_get(NULL, "MemorySwapStatsIntervalMinutes", value, sizeof(value)) == 0 )
+        if(syscfg_get(NULL, "MemorySwapStatsIntervalMinutes", value, sizeof(value)) == 0)
         {
             *puLong = atol(value);
             return TRUE;
         }
-        else        {
-            CcspTraceError(("syscfg_get failed for MemorySwapStatsIntervalMinutes\n"));
+        else
+        {
+            CcspTraceError(("%s: syscfg_get failed for MemorySwapStatsIntervalMinutes\n", __FUNCTION__));
             return FALSE;
         }
     }
@@ -25742,7 +25743,7 @@ MEMSWAP_SetParamUlongValue
 
         if (syscfg_set_u_commit(NULL, "MemorySwapDiskSizeMB", uValue) != 0)
         {
-            CcspTraceError(("syscfg_set failed for MemorySwapDiskSizeMB\n"));
+            CcspTraceError(("%s: syscfg_set failed for MemorySwapDiskSizeMB\n", __FUNCTION__));
             return FALSE;
         }
 
@@ -25765,13 +25766,13 @@ MEMSWAP_SetParamUlongValue
             case 120:
                 break;
             default:
-                CcspTraceWarning(("StatsInterval value should be a factor of 60 (e.g. 10, 12, 15, 20, 30, 60)\n"));
+                CcspTraceWarning(("StatsInterval value should divide evenly into 60 or be a clean hour block up to 2 hours\n"));
                 return FALSE; // Invalid (e.g. 25, 45, 122, etc)
         }
 
         if (syscfg_set_u_commit(NULL, "MemorySwapStatsIntervalMinutes", uValue) != 0)
         {
-            CcspTraceError(("syscfg_set failed for MemorySwapStatsIntervalMinutes\n"));
+            CcspTraceError(("%s: syscfg_set failed for MemorySwapStatsIntervalMinutes\n", __FUNCTION__));
             return FALSE;
         }
         return TRUE;
@@ -25821,37 +25822,39 @@ Tunables_GetParamUlongValue
     if (strcmp(ParamName, "Swappiness") == 0)
     {
         char value[8] = {0};
-        if( syscfg_get(NULL, "MemorySwapTunablesSwappiness", value, sizeof(value)) == 0 )
+        if(syscfg_get(NULL, "MemorySwapTunablesSwappiness", value, sizeof(value)) == 0)
         {
             *puLong = atol(value);
             return TRUE;
         }
         else        {
-            CcspTraceError(("syscfg_get failed for MemorySwapTunablesSwappiness\n"));
+            CcspTraceError(("%s: syscfg_get failed for MemorySwapTunablesSwappiness\n", __FUNCTION__));
             return FALSE;
         }
     } else if (strcmp(ParamName, "WatermarkScaleFactor") == 0)
     {
         char value[8] = {0};
-        if( syscfg_get(NULL, "MemorySwapTunablesWatermarkScaleFactor", value, sizeof(value)) == 0 )
+        if(syscfg_get(NULL, "MemorySwapTunablesWatermarkScaleFactor", value, sizeof(value)) == 0)
         {
             *puLong = atol(value);
             return TRUE;
         }
-        else        {
-            CcspTraceError(("syscfg_get failed for MemorySwapTunablesWatermarkScaleFactor\n"));
+        else
+        {
+            CcspTraceError(("%s: syscfg_get failed for MemorySwapTunablesWatermarkScaleFactor\n", __FUNCTION__));
             return FALSE;
         }
     } else if (strcmp(ParamName, "PageCluster") == 0)
     {
         char value[8] = {0};
-        if( syscfg_get(NULL, "MemorySwapTunablesPageCluster", value, sizeof(value)) == 0 )
+        if(syscfg_get(NULL, "MemorySwapTunablesPageCluster", value, sizeof(value)) == 0)
         {
             *puLong = atol(value);
             return TRUE;
         }
-        else        {
-            CcspTraceError(("syscfg_get failed for MemorySwapTunablesPageCluster\n"));
+        else
+        {
+            CcspTraceError(("%s: syscfg_get failed for MemorySwapTunablesPageCluster\n", __FUNCTION__));
             return FALSE;
         }
     }
@@ -25906,7 +25909,7 @@ Tunables_SetParamUlongValue
         }
         if (syscfg_set_u_commit(NULL, "MemorySwapTunablesSwappiness", uValue) != 0)
         {
-            CcspTraceError(("syscfg_set failed for MemorySwapTunablesSwappiness\n"));
+            CcspTraceError(("%s: syscfg_set failed for MemorySwapTunablesSwappiness\n", __FUNCTION__));
             return FALSE;
         }
         return TRUE;
@@ -25918,7 +25921,7 @@ Tunables_SetParamUlongValue
         }
         if (syscfg_set_u_commit(NULL, "MemorySwapTunablesWatermarkScaleFactor", uValue) != 0)
         {
-            CcspTraceError(("syscfg_set failed for MemorySwapTunablesWatermarkScaleFactor\n"));
+            CcspTraceError(("%s: syscfg_set failed for MemorySwapTunablesWatermarkScaleFactor\n", __FUNCTION__));
             return FALSE;
         }
         return TRUE;
@@ -25930,7 +25933,7 @@ Tunables_SetParamUlongValue
         }
         if (syscfg_set_u_commit(NULL, "MemorySwapTunablesPageCluster", uValue) != 0)
         {
-            CcspTraceError(("syscfg_set failed for MemorySwapTunablesPageCluster\n"));
+            CcspTraceError(("%s: syscfg_set failed for MemorySwapTunablesPageCluster\n", __FUNCTION__));
             return FALSE;
         }
         return TRUE;

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -10110,35 +10110,35 @@ SyndicationFlowControl_GetParamStringValue
     return:     TRUE if succeeded.
 
 **********************************************************************/
-BOOL
-MEMSWAP_GetParamBoolValue
-
-    (
-        ANSC_HANDLE                 hInsContext,
-        char*                       ParamName,
-        BOOL*                       pBool
-    )
-{
-    UNREFERENCED_PARAMETER(hInsContext);
-    if (strcmp(ParamName, "Enable") == 0)
-    {
-       /* Collect Value */
-       char *strValue = NULL;
-       int retPsmGet = CCSP_SUCCESS;
-
-
-        retPsmGet = PSM_Get_Record_Value2(bus_handle,g_Subsystem, "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Enable", NULL, &strValue);
-        if (retPsmGet == CCSP_SUCCESS) {
-            *pBool = _ansc_atoi(strValue);
-            ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(strValue);
-        }
-        else
-            *pBool = FALSE;
-
-         return TRUE;
-    }
-    return FALSE;
-}
+// BOOL
+// MEMSWAP_GetParamBoolValue
+//
+//     (
+//         ANSC_HANDLE                 hInsContext,
+//         char*                       ParamName,
+//         BOOL*                       pBool
+//     )
+// {
+//     UNREFERENCED_PARAMETER(hInsContext);
+//     if (strcmp(ParamName, "Enable") == 0)
+//     {
+//        /* Collect Value */
+//        char *strValue = NULL;
+//        int retPsmGet = CCSP_SUCCESS;
+//
+//
+//         retPsmGet = PSM_Get_Record_Value2(bus_handle,g_Subsystem, "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Enable", NULL, &strValue);
+//         if (retPsmGet == CCSP_SUCCESS) {
+//             *pBool = _ansc_atoi(strValue);
+//             ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(strValue);
+//         }
+//         else
+//             *pBool = FALSE;
+//
+//          return TRUE;
+//     }
+//     return FALSE;
+// }
 
 
 /**********************************************************************
@@ -12234,31 +12234,31 @@ UploadLogsOnUnscheduledReboot_SetParamBoolValue
     return:     TRUE if succeeded.
 
 **********************************************************************/
-BOOL
-MEMSWAP_SetParamBoolValue
-    (
-        ANSC_HANDLE                 hInsContext,
-        char*                       ParamName,
-        BOOL                        bValue
-    )
-{
-    if (IsBoolSame(hInsContext, ParamName, bValue, MEMSWAP_GetParamBoolValue))
-        return TRUE;
-
-    if (strcmp(ParamName, "Enable") == 0)
-    {
-       int retPsmGet = CCSP_SUCCESS;
-
-       retPsmGet = PSM_Set_Record_Value2(bus_handle,g_Subsystem, "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Enable", ccsp_string, bValue ? "1" : "0");
-       if (retPsmGet != CCSP_SUCCESS) {
-           CcspTraceError(("Set failed for MEMSWAP support \n"));
-           return FALSE;
-       }
-       CcspTraceInfo(("Successfully set MEMSWAP support \n"));
-       return TRUE;
-    }
-    return FALSE;
-}
+// BOOL
+// MEMSWAP_SetParamBoolValue
+//     (
+//         ANSC_HANDLE                 hInsContext,
+//         char*                       ParamName,
+//         BOOL                        bValue
+//     )
+// {
+//     if (IsBoolSame(hInsContext, ParamName, bValue, MEMSWAP_GetParamBoolValue))
+//         return TRUE;
+//
+//     if (strcmp(ParamName, "Enable") == 0)
+//     {
+//        int retPsmGet = CCSP_SUCCESS;
+//
+//        retPsmGet = PSM_Set_Record_Value2(bus_handle,g_Subsystem, "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Enable", ccsp_string, bValue ? "1" : "0");
+//        if (retPsmGet != CCSP_SUCCESS) {
+//            CcspTraceError(("Set failed for MEMSWAP support \n"));
+//            return FALSE;
+//        }
+//        CcspTraceInfo(("Successfully set MEMSWAP support \n"));
+//        return TRUE;
+//     }
+//     return FALSE;
+// }
 
 /**********************************************************************
 
@@ -25614,5 +25614,220 @@ LatencyMeasureTcpSetupIPv6_SetParamBoolValue
 
     return FALSE;
 
+}
+
+// TODO: Define in proper place
+#define ZRAM_DEVICE "zram0"
+uint32_t zram_disk_size = 300; /* 300MB */
+uint32_t zram_stats_interval = 30; /* 30 minutes */
+uint32_t swappiness = 200; /* Default swappiness value */
+uint32_t watermark_scale_factor = 80; /* Default watermark scale factor */
+uint32_t page_cluster = 0; /* Default page cluster value */
+
+// TODO: Formattings and comments
+BOOL
+MEMSWAP_GetParamBoolValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        BOOL*                       pBool
+    )
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+    if (strcmp(ParamName, "Enable") == 0)
+    {
+        struct sysinfo info;
+        int ret = sysinfo(&info);
+        if (ret != 0) {
+            CcspTraceError(("sysinfo failed: %s\n", strerror(errno)));
+            return FALSE;
+        }
+
+        *pBool = (info.totalswap > 0) ? TRUE : FALSE;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+BOOL
+MEMSWAP_SetParamBoolValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        BOOL                        bValue
+    )
+{
+    if (IsBoolSame(hInsContext, ParamName, bValue, MEMSWAP_GetParamBoolValue))
+    {
+        return TRUE;
+    }
+
+    if (strcmp(ParamName, "Enable") == 0)
+    {
+        // Format ZRAM block device path
+        char zram_device_path[64];
+        snprintf(zram_device_path, sizeof(zram_device_path), "/dev/%s", ZRAM_DEVICE);
+
+        if (bValue) {
+            // Reset the ZRAM device before configuring
+            char reset_path[64];
+            snprintf(reset_path, sizeof(reset_path), "/sys/block/%s/reset", ZRAM_DEVICE);
+            FILE *fp = fopen(reset_path, "w");
+            if (fp == NULL) {
+                CcspTraceError(("Failed to open %s for writing\n", reset_path));
+                return FALSE;
+            }
+            fprintf(fp, "1");
+            fclose(fp);
+
+            // Configure disk size for ZRAM device
+            char disk_size_path[64];
+            snprintf(disk_size_path, sizeof(disk_size_path), "/sys/block/%s/disksize", ZRAM_DEVICE);
+            fp = fopen(disk_size_path, "w");
+            if (fp == NULL) {
+                CcspTraceError(("Failed to open %s for writing\n", disk_size_path));
+                return FALSE;
+            }
+            fprintf(fp, "%uM", zram_disk_size);
+            fclose(fp);
+
+            // Configure swappiness
+            v_secure_system("sysctl -w vm.swappiness=%u", swappiness);
+
+            // Configure watermark scale factor
+            v_secure_system("sysctl -w vm.watermark_scale_factor=%u", watermark_scale_factor);
+
+            // Configure page cluster
+            v_secure_system("sysctl -w vm.page-cluster=%u", page_cluster);
+
+            // Format the ZRAM device for SWAP
+            v_secure_system("/sbin/mkswap %s", zram_device_path);
+
+            // Enable SWAP on the ZRAM device
+            v_secure_system("/sbin/swapon %s", zram_device_path);
+        } else {
+            // Disable SWAP
+            v_secure_system("/sbin/swapoff %s", zram_device_path);
+        }
+        return TRUE;
+    }
+    return FALSE;
+}
+
+BOOL
+MEMSWAP_GetParamUlongValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        ULONG*                      puLong
+    )
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+    if (strcmp(ParamName, "DiskSize") == 0)
+    {
+        *puLong = zram_disk_size;
+        return TRUE;
+    } else if (strcmp(ParamName, "StatsInterval") == 0)
+    {
+        // For demonstration, returning a fixed value. This can be extended to read from actual stats if needed.
+        *puLong = 60; // Stats collection interval in seconds
+        return TRUE;
+    }
+    return FALSE;
+}
+
+BOOL
+MEMSWAP_SetParamUlongValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        ULONG                       uValue
+    )
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+
+    if (strcmp(ParamName, "DiskSize") == 0)
+    {
+        if (uValue < 50 || uValue > 1024 ) {
+            CcspTraceWarning(("DiskSize value should be between 50MB and 1GB\n"));
+            return FALSE;
+        }
+        zram_disk_size = uValue;
+        return TRUE;
+    } else if (strcmp(ParamName, "StatsInterval") == 0) {
+        if (uValue < 10 || uValue > 120) {
+            CcspTraceWarning(("StatsInterval value should be between 10 seconds and 1 hour\n"));
+            return FALSE;
+        }
+        zram_stats_interval = uValue;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+BOOL
+Tunables_GetParamUlongValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        ULONG*                      pValue
+    )
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+    if (strcmp(ParamName, "Swappiness") == 0)
+    {
+        *pValue = swappiness;
+        return TRUE;
+    } else if (strcmp(ParamName, "WatermarkScaleFactor") == 0)
+    {
+        *pValue = watermark_scale_factor;
+        return TRUE;
+    } else if (strcmp(ParamName, "PageCluster") == 0)
+    {
+        *pValue = page_cluster;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+BOOL
+Tunables_SetParamUlongValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        ULONG                       uValue
+    )
+{
+    UNREFERENCED_PARAMETER(hInsContext);
+
+    if (strcmp(ParamName, "Swappiness") == 0)
+    {
+        if (uValue > 200) {
+            CcspTraceWarning(("Swappiness value should be between 0 and 200\n"));
+            return FALSE;
+        }
+        swappiness = uValue;
+        v_secure_system("sysctl -w vm.swappiness=%u", swappiness);
+        return TRUE;
+    } else if (strcmp(ParamName, "WatermarkScaleFactor") == 0)
+    {
+        if (uValue < 10 || uValue > 200) {
+            CcspTraceWarning(("WatermarkScaleFactor value should be between 10 and 200\n"));
+            return FALSE;
+        }
+        watermark_scale_factor = uValue;
+        v_secure_system("sysctl -w vm.watermark_scale_factor=%u", watermark_scale_factor);
+        return TRUE;
+    } else if (strcmp(ParamName, "PageCluster") == 0)
+    {
+        if (uValue > 3) {
+            CcspTraceWarning(("PageCluster value should be between 0 and 3\n"));
+            return FALSE;
+        }
+        page_cluster = uValue;
+        v_secure_system("sysctl -w vm.page-cluster=%u", page_cluster);
+        return TRUE;
+    }
+    return FALSE;
 }
 

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -25752,6 +25752,23 @@ MEMSWAP_SetParamUlongValue
             CcspTraceWarning(("StatsInterval value should be between 10 minutes and 2 hours\n"));
             return FALSE;
         }
+
+        // To prevent irregular intervals at the top of the hour, we only allow values that divide
+        // evenly into 1 hour (10, 12, 15, 20, 30) or represent clean hour blocks (60, 120).
+        switch (uValue) {
+            case 10:
+            case 12:
+            case 15:
+            case 20:
+            case 30:
+            case 60:
+            case 120:
+                break;
+            default:
+                CcspTraceWarning(("StatsInterval value should be a factor of 60 (e.g. 10, 12, 15, 20, 30, 60)\n"));
+                return FALSE; // Invalid (e.g. 25, 45, 122, etc)
+        }
+
         if (syscfg_set_u_commit(NULL, "MemorySwapStatsIntervalMinutes", uValue) != 0)
         {
             CcspTraceError(("syscfg_set failed for MemorySwapStatsIntervalMinutes\n"));

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -10087,67 +10087,6 @@ SyndicationFlowControl_GetParamStringValue
     prototype:
 
         BOOL
-        MEMSWAP_GetParamBoolValue
-            (
-                ANSC_HANDLE                 hInsContext,
-                char*                       ParamName,
-                BOOL*                       pBool
-            );
-
-    description:
-
-        This function is called to retrieve Boolean parameter value;
-
-    argument:   ANSC_HANDLE                 hInsContext,
-                The instance handle;
-
-                char*                       ParamName,
-                The parameter name;
-
-                BOOL*                       pBool
-                The buffer of returned boolean value;
-
-    return:     TRUE if succeeded.
-
-**********************************************************************/
-// BOOL
-// MEMSWAP_GetParamBoolValue
-//
-//     (
-//         ANSC_HANDLE                 hInsContext,
-//         char*                       ParamName,
-//         BOOL*                       pBool
-//     )
-// {
-//     UNREFERENCED_PARAMETER(hInsContext);
-//     if (strcmp(ParamName, "Enable") == 0)
-//     {
-//        /* Collect Value */
-//        char *strValue = NULL;
-//        int retPsmGet = CCSP_SUCCESS;
-//
-//
-//         retPsmGet = PSM_Get_Record_Value2(bus_handle,g_Subsystem, "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Enable", NULL, &strValue);
-//         if (retPsmGet == CCSP_SUCCESS) {
-//             *pBool = _ansc_atoi(strValue);
-//             ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(strValue);
-//         }
-//         else
-//             *pBool = FALSE;
-//
-//          return TRUE;
-//     }
-//     return FALSE;
-// }
-
-
-/**********************************************************************
-
-    caller:     owner of this object
-
-    prototype:
-
-        BOOL
         DNSSTRICTORDER_GetParamBoolValue
             (
                 ANSC_HANDLE                 hInsContext,

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -12203,63 +12203,6 @@ UploadLogsOnUnscheduledReboot_SetParamBoolValue
     return FALSE;
 }
 
-
-/**********************************************************************
-
-    caller:     owner of this object
-
-    prototype:
-
-        BOOL
-        MEMSWAP_SetParamBoolValue
-            (
-                ANSC_HANDLE                 hInsContext,
-                char*                       ParamName,
-                BOOL                        bValue
-            );
-
-    description:
-
-        This function is called to set BOOL parameter value;
-
-    argument:   ANSC_HANDLE                 hInsContext,
-                The instance handle;
-
-                char*                       ParamName,
-                The parameter name;
-
-                BOOL                        bValue
-                The updated BOOL value;
-
-    return:     TRUE if succeeded.
-
-**********************************************************************/
-// BOOL
-// MEMSWAP_SetParamBoolValue
-//     (
-//         ANSC_HANDLE                 hInsContext,
-//         char*                       ParamName,
-//         BOOL                        bValue
-//     )
-// {
-//     if (IsBoolSame(hInsContext, ParamName, bValue, MEMSWAP_GetParamBoolValue))
-//         return TRUE;
-//
-//     if (strcmp(ParamName, "Enable") == 0)
-//     {
-//        int retPsmGet = CCSP_SUCCESS;
-//
-//        retPsmGet = PSM_Set_Record_Value2(bus_handle,g_Subsystem, "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Enable", ccsp_string, bValue ? "1" : "0");
-//        if (retPsmGet != CCSP_SUCCESS) {
-//            CcspTraceError(("Set failed for MEMSWAP support \n"));
-//            return FALSE;
-//        }
-//        CcspTraceInfo(("Successfully set MEMSWAP support \n"));
-//        return TRUE;
-//     }
-//     return FALSE;
-// }
-
 /**********************************************************************
 
     caller:     owner of this object
@@ -25616,14 +25559,6 @@ LatencyMeasureTcpSetupIPv6_SetParamBoolValue
 
 }
 
-// TODO: Define in proper place
-#define ZRAM_DEVICE "zram0"
-uint32_t zram_disk_size = 300; /* 300MB */
-uint32_t zram_stats_interval = 30; /* 30 minutes */
-uint32_t swappiness = 200; /* Default swappiness value */
-uint32_t watermark_scale_factor = 80; /* Default watermark scale factor */
-uint32_t page_cluster = 0; /* Default page cluster value */
-
 // TODO: Formattings and comments
 BOOL
 MEMSWAP_GetParamBoolValue
@@ -25636,19 +25571,52 @@ MEMSWAP_GetParamBoolValue
     UNREFERENCED_PARAMETER(hInsContext);
     if (strcmp(ParamName, "Enable") == 0)
     {
-        struct sysinfo info;
-        int ret = sysinfo(&info);
-        if (ret != 0) {
-            CcspTraceError(("sysinfo failed: %s\n", strerror(errno)));
+        char value[8] = {};
+        if( syscfg_get(NULL, "MemorySwapEnable", value, sizeof(value)) == 0 )
+        {
+            *pBool = (strcmp(value, "true") == 0) ? TRUE : FALSE;
+            return TRUE;
+        }
+        else
+        {
+            CcspTraceError(("syscfg_get failed for MemorySwapEnable\n"));
             return FALSE;
         }
-
-        *pBool = (info.totalswap > 0) ? TRUE : FALSE;
-        return TRUE;
     }
+
     return FALSE;
 }
 
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        MEMSWAP_SetParamBoolValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                BOOL                        bValue
+            );
+
+    description:
+
+        This function is called to set BOOL parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                BOOL                        bValue
+                The updated BOOL value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
 BOOL
 MEMSWAP_SetParamBoolValue
     (
@@ -25664,53 +25632,14 @@ MEMSWAP_SetParamBoolValue
 
     if (strcmp(ParamName, "Enable") == 0)
     {
-        // Format ZRAM block device path
-        char zram_device_path[64];
-        snprintf(zram_device_path, sizeof(zram_device_path), "/dev/%s", ZRAM_DEVICE);
-
-        if (bValue) {
-            // Reset the ZRAM device before configuring
-            char reset_path[64];
-            snprintf(reset_path, sizeof(reset_path), "/sys/block/%s/reset", ZRAM_DEVICE);
-            FILE *fp = fopen(reset_path, "w");
-            if (fp == NULL) {
-                CcspTraceError(("Failed to open %s for writing\n", reset_path));
-                return FALSE;
-            }
-            fprintf(fp, "1");
-            fclose(fp);
-
-            // Configure disk size for ZRAM device
-            char disk_size_path[64];
-            snprintf(disk_size_path, sizeof(disk_size_path), "/sys/block/%s/disksize", ZRAM_DEVICE);
-            fp = fopen(disk_size_path, "w");
-            if (fp == NULL) {
-                CcspTraceError(("Failed to open %s for writing\n", disk_size_path));
-                return FALSE;
-            }
-            fprintf(fp, "%uM", zram_disk_size);
-            fclose(fp);
-
-            // Configure swappiness
-            v_secure_system("sysctl -w vm.swappiness=%u", swappiness);
-
-            // Configure watermark scale factor
-            v_secure_system("sysctl -w vm.watermark_scale_factor=%u", watermark_scale_factor);
-
-            // Configure page cluster
-            v_secure_system("sysctl -w vm.page-cluster=%u", page_cluster);
-
-            // Format the ZRAM device for SWAP
-            v_secure_system("/sbin/mkswap %s", zram_device_path);
-
-            // Enable SWAP on the ZRAM device
-            v_secure_system("/sbin/swapon %s", zram_device_path);
-        } else {
-            // Disable SWAP
-            v_secure_system("/sbin/swapoff %s", zram_device_path);
+        if (syscfg_set_commit(NULL, "MemorySwapEnable", bValue ? "true" : "false") != 0)
+        {
+            CcspTraceError(("syscfg_set failed for MemorySwapEnable\n"));
+            return FALSE;
         }
         return TRUE;
     }
+
     return FALSE;
 }
 
@@ -25725,13 +25654,29 @@ MEMSWAP_GetParamUlongValue
     UNREFERENCED_PARAMETER(hInsContext);
     if (strcmp(ParamName, "DiskSize") == 0)
     {
-        *puLong = zram_disk_size;
-        return TRUE;
+        char value[8] = {0};
+        if( syscfg_get(NULL, "MemorySwapDiskSizeMB", value, sizeof(value)) == 0 )
+        {
+            *puLong = atol(value);
+            return TRUE;
+        }
+        else
+        {
+            CcspTraceError(("syscfg_get failed for MemorySwapDiskSizeMB\n"));
+            return FALSE;
+        }
     } else if (strcmp(ParamName, "StatsInterval") == 0)
     {
-        // For demonstration, returning a fixed value. This can be extended to read from actual stats if needed.
-        *puLong = 60; // Stats collection interval in seconds
-        return TRUE;
+        char value[8] = {0};
+        if( syscfg_get(NULL, "MemorySwapStatsIntervalMinutes", value, sizeof(value)) == 0 )
+        {
+            *puLong = atol(value);
+            return TRUE;
+        }
+        else        {
+            CcspTraceError(("syscfg_get failed for MemorySwapStatsIntervalMinutes\n"));
+            return FALSE;
+        }
     }
     return FALSE;
 }
@@ -25752,14 +25697,24 @@ MEMSWAP_SetParamUlongValue
             CcspTraceWarning(("DiskSize value should be between 50MB and 1GB\n"));
             return FALSE;
         }
-        zram_disk_size = uValue;
+
+        if (syscfg_set_u_commit(NULL, "MemorySwapDiskSizeMB", uValue) != 0)
+        {
+            CcspTraceError(("syscfg_set failed for MemorySwapDiskSizeMB\n"));
+            return FALSE;
+        }
+
         return TRUE;
     } else if (strcmp(ParamName, "StatsInterval") == 0) {
         if (uValue < 10 || uValue > 120) {
-            CcspTraceWarning(("StatsInterval value should be between 10 seconds and 1 hour\n"));
+            CcspTraceWarning(("StatsInterval value should be between 10 minutes and 2 hours\n"));
             return FALSE;
         }
-        zram_stats_interval = uValue;
+        if (syscfg_set_u_commit(NULL, "MemorySwapStatsIntervalMinutes", uValue) != 0)
+        {
+            CcspTraceError(("syscfg_set failed for MemorySwapStatsIntervalMinutes\n"));
+            return FALSE;
+        }
         return TRUE;
     }
     return FALSE;
@@ -25776,16 +25731,40 @@ Tunables_GetParamUlongValue
     UNREFERENCED_PARAMETER(hInsContext);
     if (strcmp(ParamName, "Swappiness") == 0)
     {
-        *pValue = swappiness;
-        return TRUE;
+        char value[8] = {0};
+        if( syscfg_get(NULL, "MemorySwapTunablesSwappiness", value, sizeof(value)) == 0 )
+        {
+            *pValue = atol(value);
+            return TRUE;
+        }
+        else        {
+            CcspTraceError(("syscfg_get failed for MemorySwapTunablesSwappiness\n"));
+            return FALSE;
+        }
     } else if (strcmp(ParamName, "WatermarkScaleFactor") == 0)
     {
-        *pValue = watermark_scale_factor;
-        return TRUE;
+        char value[8] = {0};
+        if( syscfg_get(NULL, "MemorySwapTunablesWatermarkScaleFactor", value, sizeof(value)) == 0 )
+        {
+            *pValue = atol(value);
+            return TRUE;
+        }
+        else        {
+            CcspTraceError(("syscfg_get failed for MemorySwapTunablesWatermarkScaleFactor\n"));
+            return FALSE;
+        }
     } else if (strcmp(ParamName, "PageCluster") == 0)
     {
-        *pValue = page_cluster;
-        return TRUE;
+        char value[8] = {0};
+        if( syscfg_get(NULL, "MemorySwapTunablesPageCluster", value, sizeof(value)) == 0 )
+        {
+            *pValue = atol(value);
+            return TRUE;
+        }
+        else        {
+            CcspTraceError(("syscfg_get failed for MemorySwapTunablesPageCluster\n"));
+            return FALSE;
+        }
     }
     return FALSE;
 }
@@ -25806,8 +25785,11 @@ Tunables_SetParamUlongValue
             CcspTraceWarning(("Swappiness value should be between 0 and 200\n"));
             return FALSE;
         }
-        swappiness = uValue;
-        v_secure_system("sysctl -w vm.swappiness=%u", swappiness);
+        if (syscfg_set_u_commit(NULL, "MemorySwapTunablesSwappiness", uValue) != 0)
+        {
+            CcspTraceError(("syscfg_set failed for MemorySwapTunablesSwappiness\n"));
+            return FALSE;
+        }
         return TRUE;
     } else if (strcmp(ParamName, "WatermarkScaleFactor") == 0)
     {
@@ -25815,8 +25797,11 @@ Tunables_SetParamUlongValue
             CcspTraceWarning(("WatermarkScaleFactor value should be between 10 and 200\n"));
             return FALSE;
         }
-        watermark_scale_factor = uValue;
-        v_secure_system("sysctl -w vm.watermark_scale_factor=%u", watermark_scale_factor);
+        if (syscfg_set_u_commit(NULL, "MemorySwapTunablesWatermarkScaleFactor", uValue) != 0)
+        {
+            CcspTraceError(("syscfg_set failed for MemorySwapTunablesWatermarkScaleFactor\n"));
+            return FALSE;
+        }
         return TRUE;
     } else if (strcmp(ParamName, "PageCluster") == 0)
     {
@@ -25824,8 +25809,11 @@ Tunables_SetParamUlongValue
             CcspTraceWarning(("PageCluster value should be between 0 and 3\n"));
             return FALSE;
         }
-        page_cluster = uValue;
-        v_secure_system("sysctl -w vm.page-cluster=%u", page_cluster);
+        if (syscfg_set_u_commit(NULL, "MemorySwapTunablesPageCluster", uValue) != 0)
+        {
+            CcspTraceError(("syscfg_set failed for MemorySwapTunablesPageCluster\n"));
+            return FALSE;
+        }
         return TRUE;
     }
     return FALSE;

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -25616,7 +25616,7 @@ MEMSWAP_SetParamBoolValue
     {
         if (syscfg_set_commit(NULL, "MemorySwapEnable", bValue ? "true" : "false") != 0)
         {
-            CcspTraceError(("%s: syscfg_set failed for MemorySwapEnable\n", __FUNCTION__));
+            CcspTraceError(("%s: syscfg_set_commit failed for MemorySwapEnable\n", __FUNCTION__));
             return FALSE;
         }
         return TRUE;
@@ -25748,7 +25748,7 @@ MEMSWAP_SetParamUlongValue
 
         if (syscfg_set_u_commit(NULL, "MemorySwapDiskSizeMB", uValue) != 0)
         {
-            CcspTraceError(("%s: syscfg_set failed for MemorySwapDiskSizeMB\n", __FUNCTION__));
+            CcspTraceError(("%s: syscfg_set_u_commit failed for MemorySwapDiskSizeMB\n", __FUNCTION__));
             return FALSE;
         }
 
@@ -25777,7 +25777,7 @@ MEMSWAP_SetParamUlongValue
 
         if (syscfg_set_u_commit(NULL, "MemorySwapStatsIntervalMinutes", uValue) != 0)
         {
-            CcspTraceError(("%s: syscfg_set failed for MemorySwapStatsIntervalMinutes\n", __FUNCTION__));
+            CcspTraceError(("%s: syscfg_set_u_commit failed for MemorySwapStatsIntervalMinutes\n", __FUNCTION__));
             return FALSE;
         }
         return TRUE;
@@ -25832,7 +25832,8 @@ Tunables_GetParamUlongValue
             *puLong = atol(value);
             return TRUE;
         }
-        else        {
+        else
+        {
             CcspTraceError(("%s: syscfg_get failed for MemorySwapTunablesSwappiness\n", __FUNCTION__));
             return FALSE;
         }
@@ -25919,7 +25920,7 @@ Tunables_SetParamUlongValue
         }
         if (syscfg_set_u_commit(NULL, "MemorySwapTunablesSwappiness", uValue) != 0)
         {
-            CcspTraceError(("%s: syscfg_set failed for MemorySwapTunablesSwappiness\n", __FUNCTION__));
+            CcspTraceError(("%s: syscfg_set_u_commit failed for MemorySwapTunablesSwappiness\n", __FUNCTION__));
             return FALSE;
         }
         return TRUE;
@@ -25931,7 +25932,7 @@ Tunables_SetParamUlongValue
         }
         if (syscfg_set_u_commit(NULL, "MemorySwapTunablesWatermarkScaleFactor", uValue) != 0)
         {
-            CcspTraceError(("%s: syscfg_set failed for MemorySwapTunablesWatermarkScaleFactor\n", __FUNCTION__));
+            CcspTraceError(("%s: syscfg_set_u_commit failed for MemorySwapTunablesWatermarkScaleFactor\n", __FUNCTION__));
             return FALSE;
         }
         return TRUE;
@@ -25943,7 +25944,7 @@ Tunables_SetParamUlongValue
         }
         if (syscfg_set_u_commit(NULL, "MemorySwapTunablesPageCluster", uValue) != 0)
         {
-            CcspTraceError(("%s: syscfg_set failed for MemorySwapTunablesPageCluster\n", __FUNCTION__));
+            CcspTraceError(("%s: syscfg_set_u_commit failed for MemorySwapTunablesPageCluster\n", __FUNCTION__));
             return FALSE;
         }
         return TRUE;

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -25559,7 +25559,50 @@ LatencyMeasureTcpSetupIPv6_SetParamBoolValue
 
 }
 
-// TODO: Formattings and comments
+/***********************************************************************
+
+ APIs for Object:
+
+    DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.
+
+    *  MEMSWAP_GetParamBoolValue
+    *  MEMSWAP_SetParamBoolValue
+    *  MEMSWAP_GetParamUlongValue
+    *  MEMSWAP_SetParamUlongValue
+    *  Tunables_GetParamUlongValue
+    *  Tunables_SetParamUlongValue
+
+***********************************************************************/
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        MEMSWAP_GetParamBoolValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                BOOL*                       pBool
+            );
+
+    description:
+
+        This function is called to retrieve Boolean parameter value; 
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                BOOL*                       pBool
+                The buffer of returned boolean value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
 BOOL
 MEMSWAP_GetParamBoolValue
     (
@@ -25643,6 +25686,36 @@ MEMSWAP_SetParamBoolValue
     return FALSE;
 }
 
+/**********************************************************************  
+
+    caller:     owner of this object 
+
+    prototype: 
+
+        BOOL
+        MEMSWAP_GetParamUlongValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                ULONG*                      puLong
+            );
+
+    description:
+
+        This function is called to retrieve ULONG parameter value; 
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                ULONG*                      puLong
+                The buffer of returned ULONG value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
 BOOL
 MEMSWAP_GetParamUlongValue
     (
@@ -25681,6 +25754,36 @@ MEMSWAP_GetParamUlongValue
     return FALSE;
 }
 
+/**********************************************************************  
+
+    caller:     owner of this object 
+
+    prototype: 
+
+        BOOL
+        MEMSWAP_SetParamUlongValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                ULONG                       uValue
+            );
+
+    description:
+
+        This function is called to set ULONG parameter value; 
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                ULONG                       uValue
+                The updated ULONG value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
 BOOL
 MEMSWAP_SetParamUlongValue
     (
@@ -25720,12 +25823,42 @@ MEMSWAP_SetParamUlongValue
     return FALSE;
 }
 
+/**********************************************************************  
+
+    caller:     owner of this object 
+
+    prototype: 
+
+        BOOL
+        Tunables_GetParamUlongValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                ULONG*                      puLong
+            );
+
+    description:
+
+        This function is called to retrieve ULONG parameter value; 
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                ULONG*                      puLong
+                The buffer of returned ULONG value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
 BOOL
 Tunables_GetParamUlongValue
     (
         ANSC_HANDLE                 hInsContext,
         char*                       ParamName,
-        ULONG*                      pValue
+        ULONG*                      puLong
     )
 {
     UNREFERENCED_PARAMETER(hInsContext);
@@ -25734,7 +25867,7 @@ Tunables_GetParamUlongValue
         char value[8] = {0};
         if( syscfg_get(NULL, "MemorySwapTunablesSwappiness", value, sizeof(value)) == 0 )
         {
-            *pValue = atol(value);
+            *puLong = atol(value);
             return TRUE;
         }
         else        {
@@ -25746,7 +25879,7 @@ Tunables_GetParamUlongValue
         char value[8] = {0};
         if( syscfg_get(NULL, "MemorySwapTunablesWatermarkScaleFactor", value, sizeof(value)) == 0 )
         {
-            *pValue = atol(value);
+            *puLong = atol(value);
             return TRUE;
         }
         else        {
@@ -25758,7 +25891,7 @@ Tunables_GetParamUlongValue
         char value[8] = {0};
         if( syscfg_get(NULL, "MemorySwapTunablesPageCluster", value, sizeof(value)) == 0 )
         {
-            *pValue = atol(value);
+            *puLong = atol(value);
             return TRUE;
         }
         else        {
@@ -25769,6 +25902,36 @@ Tunables_GetParamUlongValue
     return FALSE;
 }
 
+/**********************************************************************  
+
+    caller:     owner of this object 
+
+    prototype: 
+
+        BOOL
+        Tunables_SetParamUlongValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                ULONG                       uValue
+            );
+
+    description:
+
+        This function is called to set ULONG parameter value; 
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                ULONG                       uValue
+                The updated ULONG value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
 BOOL
 Tunables_SetParamUlongValue
     (

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -25553,7 +25553,7 @@ MEMSWAP_GetParamBoolValue
     UNREFERENCED_PARAMETER(hInsContext);
     if (strcmp(ParamName, "Enable") == 0)
     {
-        char value[8] = {};
+        char value[8] = {0};
         if( syscfg_get(NULL, "MemorySwapEnable", value, sizeof(value)) == 0 )
         {
             *pBool = (strcmp(value, "true") == 0) ? TRUE : FALSE;

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -25734,6 +25734,11 @@ MEMSWAP_SetParamUlongValue
 {
     UNREFERENCED_PARAMETER(hInsContext);
 
+    if (IsUlongSame(hInsContext, ParamName, uValue, MEMSWAP_GetParamUlongValue))
+    {
+        return TRUE;
+    }
+
     if (strcmp(ParamName, "DiskSize") == 0)
     {
         if (uValue < 50 || uValue > 1024 ) {
@@ -25900,6 +25905,11 @@ Tunables_SetParamUlongValue
     )
 {
     UNREFERENCED_PARAMETER(hInsContext);
+
+    if (IsUlongSame(hInsContext, ParamName, uValue, Tunables_GetParamUlongValue))
+    {
+        return TRUE;
+    }
 
     if (strcmp(ParamName, "Swappiness") == 0)
     {

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.h
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.h
@@ -5012,7 +5012,7 @@ APIs for Object:
 /**
  * @brief Retrieves boolean parameter values for MEMSWAP object.
  *
- * @param[in]  hInsContext - Instance handle for the MEMSWAP object.
+ * @param[in]  hInsContext - Instance handle for the MEMSWAP context.
  * @param[in]  ParamName   - Pointer to the parameter name
  * @param[out] pBool       - Pointer to store the boolean value.
  *
@@ -5029,10 +5029,10 @@ MEMSWAP_GetParamBoolValue
     );
 
 /**
- * @brief Sets boolean parameter values for MACsec required feature enable status.
+ * @brief Sets boolean parameter values for the MEMSWAP object.
  *
- * @param[in] hInsContext Instance handle for the MACsecRequired context.
- * @param[in] ParamName   Name of the boolean parameter to set (minimum 1 byte, maximum 256 bytes).
+ * @param[in] hInsContext Instance handle for the MEMSWAP context.
+ * @param[in] ParamName   Pointer to the parameter name.
  * @param[in] bValue      Boolean value to set.
  *
  * @return The status of the operation
@@ -5047,6 +5047,18 @@ MEMSWAP_SetParamBoolValue
         BOOL                        bValue
     );
 
+/**
+ * @brief Get unsigned long parameter value from MEMSWAP object.
+ *
+ * @param[in] hInsContext - The instance handle to the MEMSWAP object.
+ * @param[in] ParamName   - Pointer to the parameter name.
+ * @param[out] pUlong     - Pointer to store the unsigned long value.
+ *
+ * @return The status of the operation.
+ * @retval TRUE if the parameter is found and retrieved successfully.
+ * @retval FALSE if the parameter is not found or operation fails.
+ *
+ */
 BOOL
 MEMSWAP_GetParamUlongValue
     (
@@ -5055,6 +5067,18 @@ MEMSWAP_GetParamUlongValue
         ULONG*                      pValue
     );
 
+/**
+ * @brief Set unsigned long parameter value for MEMSWAP object.
+ *
+ * @param[in] hInsContext  - The instance handle to the MEMSWAP object.
+ * @param[in] ParamName    - Pointer to the parameter name.
+ * @param[in] uValuepUlong - The unsigned long value to set.
+ *
+ * @return The status of the operation.
+ * @retval TRUE if the parameter is set successfully.
+ * @retval FALSE if the parameter is not found or operation fails.
+ *
+ */
 BOOL
 MEMSWAP_SetParamUlongValue
     (
@@ -5063,6 +5087,18 @@ MEMSWAP_SetParamUlongValue
         ULONG                       value
     );
 
+/**
+ * @brief Get unsigned long parameter value from TUNABLES object.
+ *
+ * @param[in] hInsContext - The instance handle to the TUNABLES object.
+ * @param[in] ParamName   - Pointer to the parameter name.
+ * @param[out] pValue     - Pointer to store the unsigned long value.
+ *
+ * @return The status of the operation.
+ * @retval TRUE if the parameter is found and retrieved successfully.
+ * @retval FALSE if the parameter is not found or operation fails.
+ *
+ */
 BOOL
 Tunables_GetParamUlongValue
     (
@@ -5071,6 +5107,18 @@ Tunables_GetParamUlongValue
         ULONG*                      pValue
     );
 
+/**
+ * @brief Set unsigned long parameter value for TUNABLES object.
+ *
+ * @param[in] hInsContext  - The instance handle to the TUNABLES object.
+ * @param[in] ParamName    - Pointer to the parameter name.
+ * @param[in] uValue       - The unsigned long value to set.
+ *
+ * @return The status of the operation.
+ * @retval TRUE if the parameter is set successfully.
+ * @retval FALSE if the parameter is not found or operation fails.
+ *
+ */
 BOOL
 Tunables_SetParamUlongValue
     (

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.h
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.h
@@ -5052,7 +5052,7 @@ MEMSWAP_SetParamBoolValue
  *
  * @param[in] hInsContext - The instance handle to the MEMSWAP object.
  * @param[in] ParamName   - Pointer to the parameter name.
- * @param[out] pUlong     - Pointer to store the unsigned long value.
+ * @param[out] pValue     - Pointer to store the unsigned long value.
  *
  * @return The status of the operation.
  * @retval TRUE if the parameter is found and retrieved successfully.

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.h
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.h
@@ -4989,4 +4989,94 @@ LatencyMeasureTcpSetupIPv6_SetParamBoolValue
         char*                       ParamName,
         BOOL                        bValue
     );
+
+/**********************************************************************
+
+APIs for Object:
+
+    Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Enable
+    Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.DiskSize
+    Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.StatsInterval
+    Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Tunables.Swappiness
+    Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Tunables.WatermarkScaleFactor
+    Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Tunables.PageCluster
+
+    *  MEMSWAP_GetParamBoolValue
+    *  MEMSWAP_GetParamUlongValue
+    *  MEMSWAP_SetParamBoolValue
+    *  MEMSWAP_SetParamUlongValue
+
+
+**********************************************************************/
+
+/**
+ * @brief Retrieves boolean parameter values for MEMSWAP object.
+ *
+ * @param[in]  hInsContext - Instance handle for the MEMSWAP object.
+ * @param[in]  ParamName   - Pointer to the parameter name
+ * @param[out] pBool       - Pointer to store the boolean value.
+ *
+ * @return The status of the operation
+ * @retval TRUE if the parameter is found and retrieved successfully.
+ * @retval FALSE if the parameter is not found or operation fails.
+ */
+BOOL
+MEMSWAP_GetParamBoolValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        BOOL*                       pBool
+    );
+
+/**
+ * @brief Sets boolean parameter values for MACsec required feature enable status.
+ *
+ * @param[in] hInsContext Instance handle for the MACsecRequired context.
+ * @param[in] ParamName   Name of the boolean parameter to set (minimum 1 byte, maximum 256 bytes).
+ * @param[in] bValue      Boolean value to set.
+ *
+ * @return The status of the operation
+ * @retval TRUE if parameter is supported and set successfully
+ * @retval FALSE otherwise.
+ */
+BOOL
+MEMSWAP_SetParamBoolValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        BOOL                        bValue
+    );
+
+BOOL
+MEMSWAP_GetParamUlongValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        ULONG*                      pValue
+    );
+
+BOOL
+MEMSWAP_SetParamUlongValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        ULONG                       value
+    );
+
+BOOL
+Tunables_GetParamUlongValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        ULONG*                      pValue
+    );
+
+BOOL
+Tunables_SetParamUlongValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        ULONG                       uValue
+    );
+
 #endif

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.h
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.h
@@ -5072,7 +5072,7 @@ MEMSWAP_GetParamUlongValue
  *
  * @param[in] hInsContext  - The instance handle to the MEMSWAP object.
  * @param[in] ParamName    - Pointer to the parameter name.
- * @param[in] uValuepUlong - The unsigned long value to set.
+ * @param[in] uValue       - The unsigned long value to set.
  *
  * @return The status of the operation.
  * @retval TRUE if the parameter is set successfully.
@@ -5084,7 +5084,7 @@ MEMSWAP_SetParamUlongValue
     (
         ANSC_HANDLE                 hInsContext,
         char*                       ParamName,
-        ULONG                       value
+        ULONG                       uValue
     );
 
 /**


### PR DESCRIPTION
The following changes are part of a larger effort to enable a ZRAM SWAP partition for Broadband devices. The objects to support the RFC are as follows:

- `Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Enable`
- `Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.DiskSize`
- `Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.StatsInterval`
- `Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Tunables.Swappiness`
- `Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Tunables.WatermarkScaleFactor`
- `Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MEMSWAP.Tunables.PageCluster`

> Note: A previous implementation of the `MEMSWAP` RFC has been removed since the devices which supported that feature are end-of-life. This implementation will apply to all active Broadband devices.