### PR TITLE
RDKB-64597 Coverity issues in ccsp-p-and-m component

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_hosts_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_hosts_apis.c
@@ -882,6 +882,8 @@ CosaDmlHostsGetHosts
     if (!hosts)
         return ANSC_STATUS_FAILURE;
 
+    /* CID 340106 - String not null terminated - Fix is added in lan-manager-lite
+    as the API lm_get_all_hosts is from lmlite code lm_api.c */
     if(LM_RET_SUCCESS == lm_get_all_hosts(hosts))
     {
         *pulCount = hosts->count;

--- a/source-arm/TR-181/board_sbapi/cosa_ra_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_ra_apis.c
@@ -193,8 +193,9 @@ static int ParseZebraRaConf(ZebraRaConf_t *conf)
 
     /* the first "interface" line */
     /*61252 - Calling risky function - Fix*/
+    /*CID 746587 fix - Out of bounds write issue - changed to %16s instead of %255s */
     if (fgets(line, sizeof(line), fp) == NULL
-            || sscanf(line, "interface %255s", conf->interface) != 1)
+            || sscanf(line, "interface %16s", conf->interface) != 1)
         goto BAD_FORMAT;
 
     while (fgets(line, sizeof(line), fp) != NULL) {

--- a/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_diagnostics_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_diagnostics_apis.c
@@ -239,7 +239,8 @@ static inline int _month2i(char *m)
 
 static inline int date2i(char *date)
 {
-    char mon[3];
+    /* CID 745860 fix - Out of bounds write issue - changed array size to 4 to hold '\0' */
+    char mon[4];
     int day,h,m,s;
     int value = 0;
 

--- a/source/TR-181/middle_layer_src/cosa_apis_util.c
+++ b/source/TR-181/middle_layer_src/cosa_apis_util.c
@@ -1910,9 +1910,11 @@ typedef struct v6sample {
            char prefix_v6[40];
 }ifv6Details;
 
-int getIpv6Scope(int scope_v6)
+/* CID 745997 fix - Overflowed Integer Argument */
+int getIpv6Scope(unsigned int scope_v6)
 {
-    int scopeToReturn = scope_v6 & IPV6_ADDR_SCOPE_MASK;
+    /* CID 745997 fix - Overflowed Integer Argument */
+    unsigned int scopeToReturn = scope_v6 & IPV6_ADDR_SCOPE_MASK;
 
             if(scopeToReturn == 0)
                 return IPV6_ADDR_SCOPE_GLOBAL;                          
@@ -2036,8 +2038,9 @@ int CosaUtilGetIpv6AddrInfo (char * ifname, ipv6_addr_info_t ** pp_info, int * p
             strncpy(p_ai->v6addr, v6Details.address6, sizeof(p_ai->v6addr));
 
             // Get the scope of IPv6
+            /* CID 745997 - Overflowed Integer Argument - getIpv6Scope definition is fixed */
             p_ai->scope = getIpv6Scope(v6Details.scopeofipv6);
-            CcspTraceInfo(("%s,Interface scope is : %d\n",__FUNCTION__,v6Details.scopeofipv6));           
+            CcspTraceInfo(("%s,Interface scope is : %u\n",__FUNCTION__,v6Details.scopeofipv6));
  
             memset(p_ai->v6pre, 0, sizeof(p_ai->v6pre));
             /*CID: 64940 - Array Compared against null - fixed*/


### PR DESCRIPTION
Reason for change: Coverity high imapct issues in ccsp-p-and-m
Test Procedure: not applicable
Risks: Low
Priority: P1