### PR TITLE
RDKB-64688 , XF10-715 : WebUI.Enable = MSOonly not opening MSO GUI

### DIFF
--- a/custom/comcast/source/TR-181/custom_sbapi/cosa_deviceinfo_apis_custom.c
+++ b/custom/comcast/source/TR-181/custom_sbapi/cosa_deviceinfo_apis_custom.c
@@ -325,19 +325,12 @@ CosaDmlDiGetRouterIPv6Address
     {
         CosaUtilGetIpv6AddrInfo("brlan0", &p_v6addr, &v6addr_num);
     }
-#if defined(_SCXF11BFL_PRODUCT_REQ_)
     else
     {
         char wan_interface[32] = {0};
         commonSyseventGet("current_wan_ifname", wan_interface, sizeof(wan_interface));
         CosaUtilGetIpv6AddrInfo(wan_interface, &p_v6addr, &v6addr_num);
     }
-#else
-    else
-    {
-        CosaUtilGetIpv6AddrInfo("erouter0", &p_v6addr, &v6addr_num);
-    }
-#endif
 #elif defined(_HUB4_PRODUCT_REQ_)
 	CosaUtilGetIpv6AddrInfo("brlan0", &p_v6addr, &v6addr_num);
 #elif defined(_WNXL11BWL_PRODUCT_REQ_)

--- a/custom/comcast/source/TR-181/custom_sbapi/cosa_deviceinfo_apis_custom.c
+++ b/custom/comcast/source/TR-181/custom_sbapi/cosa_deviceinfo_apis_custom.c
@@ -325,10 +325,19 @@ CosaDmlDiGetRouterIPv6Address
     {
         CosaUtilGetIpv6AddrInfo("brlan0", &p_v6addr, &v6addr_num);
     }
+#if defined(_SCXF11BFL_PRODUCT_REQ_)
+    else
+    {
+        char wan_interface[32] = {0};
+        commonSyseventGet("current_wan_ifname", wan_interface, sizeof(wan_interface));
+        CosaUtilGetIpv6AddrInfo(wan_interface, &p_v6addr, &v6addr_num);
+    }
+#else
     else
     {
         CosaUtilGetIpv6AddrInfo("erouter0", &p_v6addr, &v6addr_num);
     }
+#endif
 #elif defined(_HUB4_PRODUCT_REQ_)
 	CosaUtilGetIpv6AddrInfo("brlan0", &p_v6addr, &v6addr_num);
 #elif defined(_WNXL11BWL_PRODUCT_REQ_)


### PR DESCRIPTION
XF10-715, RDKB-64688 : WebUI.Enable = MSOonly not opening MSO GUI

Reason for change: WANIPV6 is empty for XF10
Test Procedure: Able to access MSO
Priority: P1
Risks: Low