### PR TITLE
RDKB-64897 Add required MAP-T enabled validation

### DIFF
--- a/source/TR-181/middle_layer_src/cosa_apis_util.c
+++ b/source/TR-181/middle_layer_src/cosa_apis_util.c
@@ -1871,8 +1871,8 @@ ANSC_STATUS is_usg_in_bridge_mode(BOOL *pBridgeMode)
 static BOOL IsTSIPConflictingFeaturesEnabled(void)
 {
 #if defined(FEATURE_SUPPORT_MAPT_NAT46) || defined(FEATURE_MAPT)
-    #define BUFLEN_8 8
-    char mapt_enable[BUFLEN_8] = {0};
+    #define MAPTBUFLEN_8 8
+    char mapt_enable[MAPTBUFLEN_8] = {0};
     if (0 == syscfg_get(NULL, "MAPT_Enable", mapt_enable, sizeof(mapt_enable)))
     {
         if (strcmp(mapt_enable, "true") == 0)

--- a/source/TR-181/middle_layer_src/cosa_apis_util.c
+++ b/source/TR-181/middle_layer_src/cosa_apis_util.c
@@ -1876,7 +1876,7 @@ static BOOL IsTSIPConflictingFeaturesEnabled(void)
         return TRUE;
     }
 #endif
-    AnscTraceWarning(("TrueStatic: No conflicting features found, enable allowed\n"));
+    CcspTraceInfo(("TrueStatic: No conflicting features found, enable allowed\n"));
     return FALSE;
 }
 

--- a/source/TR-181/middle_layer_src/cosa_apis_util.c
+++ b/source/TR-181/middle_layer_src/cosa_apis_util.c
@@ -1887,7 +1887,7 @@ ANSC_STATUS CheckTSIPModeGate(BOOL bEnable)
 
     if (!isFeatureSupportedInCurrentMode(FEATURE_TRUE_STATIC_IP))
     {
-        AnscTraceWarning(("TrueStatic enable rejected, unsupported mode\n"));
+        AnscTraceWarning(("TrueStatic enable rejected, not supported in current system settings\n"));
         t2_event_d("TrueStatic_NotSupported", 1);
         return ANSC_STATUS_FAILURE;
     }

--- a/source/TR-181/middle_layer_src/cosa_apis_util.c
+++ b/source/TR-181/middle_layer_src/cosa_apis_util.c
@@ -1871,8 +1871,7 @@ ANSC_STATUS is_usg_in_bridge_mode(BOOL *pBridgeMode)
 static BOOL IsTSIPConflictingFeaturesEnabled(void)
 {
 #if defined(FEATURE_SUPPORT_MAPT_NAT46) || defined(FEATURE_MAPT)
-    #define MAPTBUFLEN_8 8
-    char mapt_enable[MAPTBUFLEN_8] = {0};
+    char mapt_enable[8] = {0};
     if (0 == syscfg_get(NULL, "MAPT_Enable", mapt_enable, sizeof(mapt_enable)))
     {
         if (strcmp(mapt_enable, "true") == 0)

--- a/source/TR-181/middle_layer_src/cosa_apis_util.c
+++ b/source/TR-181/middle_layer_src/cosa_apis_util.c
@@ -1871,9 +1871,14 @@ ANSC_STATUS is_usg_in_bridge_mode(BOOL *pBridgeMode)
 static BOOL IsTSIPConflictingFeaturesEnabled(void)
 {
 #if defined(FEATURE_SUPPORT_MAPT_NAT46) || defined(FEATURE_MAPT)
-    if (CosaGetParamValueBool("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MAP-T.Enable"))
+    char mapt_enable[8] = {0};
+    if (0 == syscfg_get(NULL, "MAPT_Enable", mapt_enable, sizeof(mapt_enable)))
     {
-        return TRUE;
+        if (strcmp(mapt_enable, "true") == 0)
+        {
+            CcspTraceInfo(("TrueStatic: enable rejected, MAP-T is active\n"));
+            return TRUE;
+        }
     }
 #endif
     CcspTraceInfo(("TrueStatic: No conflicting features found, enable allowed\n"));

--- a/source/TR-181/middle_layer_src/cosa_apis_util.c
+++ b/source/TR-181/middle_layer_src/cosa_apis_util.c
@@ -1870,7 +1870,13 @@ ANSC_STATUS is_usg_in_bridge_mode(BOOL *pBridgeMode)
 #if defined(_ONESTACK_PRODUCT_REQ_)
 static BOOL IsTSIPConflictingFeaturesEnabled(void)
 {
-    /* TODO: MAP-T and True Static IP are mutually exclusive */
+#if defined(FEATURE_SUPPORT_MAPT_NAT46) || defined(FEATURE_MAPT)
+    if (CosaGetParamValueBool("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MAP-T.Enable"))
+    {
+        return TRUE;
+    }
+#endif
+    AnscTraceWarning(("TrueStatic: No conflicting features found, enable allowed\n"));
     return FALSE;
 }
 

--- a/source/TR-181/middle_layer_src/cosa_apis_util.c
+++ b/source/TR-181/middle_layer_src/cosa_apis_util.c
@@ -1871,7 +1871,8 @@ ANSC_STATUS is_usg_in_bridge_mode(BOOL *pBridgeMode)
 static BOOL IsTSIPConflictingFeaturesEnabled(void)
 {
 #if defined(FEATURE_SUPPORT_MAPT_NAT46) || defined(FEATURE_MAPT)
-    char mapt_enable[8] = {0};
+    #define BUFLEN_8 8
+    char mapt_enable[BUFLEN_8] = {0};
     if (0 == syscfg_get(NULL, "MAPT_Enable", mapt_enable, sizeof(mapt_enable)))
     {
         if (strcmp(mapt_enable, "true") == 0)

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -11582,11 +11582,14 @@ Feature_SetParamBoolValue
     if (strcmp(ParamName, "OneToOneNAT") == 0)
     {
 #if defined(_ONESTACK_PRODUCT_REQ_)
-        if(!isFeatureSupportedInCurrentMode(FEATURE_TRUE_STATIC_IP))
+        if (bValue)
         {
-            CcspTraceError(("OneToOneNAT is not supported in non business mode \n"));
-            t2_event_d("OneToOneNAT_NotSupported", 1);
-            return FALSE;
+            if (!isFeatureSupportedInCurrentMode(FEATURE_TRUE_STATIC_IP))
+            {
+                CcspTraceError(("OneToOneNAT is not supported in non business mode \n"));
+                t2_event_d("OneToOneNAT_NotSupported", 1);
+                return FALSE;
+            }
         }
 #endif
         BOOL bNatEnable = FALSE;

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -11586,7 +11586,7 @@ Feature_SetParamBoolValue
         {
             if (!isFeatureSupportedInCurrentMode(FEATURE_TRUE_STATIC_IP))
             {
-                CcspTraceError(("OneToOneNAT is not supported in non business mode \n"));
+                CcspTraceError(("OneToOneNAT is not supported in current system settings \n"));
                 t2_event_d("OneToOneNAT_NotSupported", 1);
                 return FALSE;
             }

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -115,6 +115,7 @@
 
 #if defined(_ONESTACK_PRODUCT_REQ_)
 #include <rdkb_feature_mode_gate.h>
+#include "cosa_apis_util.h"
 #endif
 
 extern ULONG g_currentBsUpdate;
@@ -11582,14 +11583,11 @@ Feature_SetParamBoolValue
     if (strcmp(ParamName, "OneToOneNAT") == 0)
     {
 #if defined(_ONESTACK_PRODUCT_REQ_)
-        if (bValue)
+        if (CheckTSIPModeGate(bValue) != ANSC_STATUS_SUCCESS)
         {
-            if (!isFeatureSupportedInCurrentMode(FEATURE_TRUE_STATIC_IP))
-            {
-                CcspTraceError(("OneToOneNAT is not supported in current system settings \n"));
-                t2_event_d("OneToOneNAT_NotSupported", 1);
-                return FALSE;
-            }
+            CcspTraceError(("OneToOneNAT is not supported in current system settings \n"));
+            t2_event_d("OneToOneNAT_NotSupported", 1);
+            return FALSE;
         }
 #endif
         BOOL bNatEnable = FALSE;


### PR DESCRIPTION
US: RDKB-64656: Subtask: RDKB-64897 Add required MAP-T enabled validation

Reason for change: Add the needed MAP-T feature enabled validation and reject the enabling of TSIP if required.

Test Procedure: Build with OneStack distro and test
Risks: None

Is this a Bug or a User Story (US)?: US: RDKB-64656 [Single Build] Support True Static Configuration in XB10 Residential Mode. Subtask: RDKB-64897
If it is a User Story:
• Gerrit topic or list of all dependent PRs across components (including meta-layer changes) been shared?:
https://github.com/rdk-gdcs/rdkb_common_utils/pull/23