### PR TITLE
RDKB-64913 Add required TSIP enabled validation

### DIFF
--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -22329,10 +22329,21 @@ UPnPRefactor_SetParamBoolValue
 
 #if defined(FEATURE_MAPT) || defined(FEATURE_SUPPORT_MAPT_NAT46)
 #if defined(_ONESTACK_PRODUCT_REQ_)
+/*
+ * Only True Static IP is checked here. Other TSIP-family features
+ * (OneToOneNAT, Firewall TrueStaticIpEnable, Static Routing) are all
+ * dependent on True Static IP being active — they are functionally
+ * inert without it. A single TSIP check is therefore considered sufficient.
+ */
 static BOOL IsMAPTConflictingFeaturesEnabled(void)
 {
-    // TODO: Add check to see if any conflicting feature of MAP-T 
-    //       like Static Routing, 1-1 NAT, etc are enabled
+    if (g_GetParamValueBool(g_pDslhDmlAgent, "Device.X_CISCO_COM_TrueStaticIP.Enable"))
+    {
+        CcspTraceInfo(("%s: MAP-T enable rejected, True Static IP is active\n", __FUNCTION__));
+        return TRUE;
+    }
+
+    CcspTraceInfo(("%s: No conflicting features found, MAP-T enable allowed\n", __FUNCTION__));
     return FALSE;
 }
 #endif

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -22333,7 +22333,7 @@ UPnPRefactor_SetParamBoolValue
 /*
  * Only True Static IP is checked here. Other TSIP-family features
  * (OneToOneNAT, Firewall TrueStaticIpEnable, Static Routing) are all
- * dependent on True Static IP being active — they are functionally
+ * dependent on True Static IP being active - they are functionally
  * inert without it. A single TSIP check is therefore considered sufficient.
  */
 static BOOL IsMAPTConflictingFeaturesEnabled(void)

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -115,6 +115,7 @@
 
 #if defined(_ONESTACK_PRODUCT_REQ_)
 #include <rdkb_feature_mode_gate.h>
+#include "cosa_x_cisco_com_truestaticip_internal.h"
 #endif
 
 extern ULONG g_currentBsUpdate;
@@ -22337,7 +22338,8 @@ UPnPRefactor_SetParamBoolValue
  */
 static BOOL IsMAPTConflictingFeaturesEnabled(void)
 {
-    if (g_GetParamValueBool(g_pDslhDmlAgent, "Device.X_CISCO_COM_TrueStaticIP.Enable"))
+    PCOSA_DATAMODEL_TSIP pTSIP = (PCOSA_DATAMODEL_TSIP)g_pCosaBEManager->hTSIP;
+    if (pTSIP && pTSIP->TSIPCfg.Enabled)
     {
         CcspTraceInfo(("%s: MAP-T enable rejected, True Static IP is active\n", __FUNCTION__));
         return TRUE;


### PR DESCRIPTION
US: RDKB-64657: Subtask: RDKB-64913 Add required TSIP enabled validation

Reason for change: Add the needed TSIP feature enabled validation and reject the enabling of MAP-T if required.

Test Procedure: Build with OneStack distro and test
Risks: None

Is this a Bug or a User Story (US)?: US: RDKB-64657 [Single Build] Support MAP-T in XB10 Commercial Mode. Subtask: RDKB-64913
If it is a User Story:
• Gerrit topic or list of all dependent PRs across components (including meta-layer changes) been shared?:
https://github.com/rdk-gdcs/rdkb_common_utils/pull/24