### PR TITLE
RDKB-62908 [PAM] [5GB]Reduce Repetitive Logging

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_deviceinfo_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_deviceinfo_apis.c
@@ -1786,8 +1786,8 @@ void COSADmlGetProcessInfo(PCOSA_DATAMODEL_PROCSTATUS p_info)
 
     p_info->ProcessNumberOfEntries = i;
 
-    fprintf(stderr,"\n %s %d  ProcessNumberOfEntries:%lu",__func__,__LINE__,p_info->ProcessNumberOfEntries);
-    CcspTraceWarning(("\n %s %d  ProcessNumberOfEntries:%lu\n",__func__,__LINE__,p_info->ProcessNumberOfEntries));
+    fprintf(stderr," %s %d  ProcessNumberOfEntries:%lu\n",__func__,__LINE__,p_info->ProcessNumberOfEntries);
+    CcspTraceWarning((" %s %d  ProcessNumberOfEntries:%lu\n",__func__,__LINE__,p_info->ProcessNumberOfEntries));
 }
 
 void test_get_proc_info()
@@ -1962,8 +1962,8 @@ ULONG COSADmlGetProcessNumberOfEntries()
         dir = NULL;
     }
 
-    fprintf(stderr,"\n %s %d  ProcessNumberOfEntries:%lu", __func__, __LINE__, i);
-    CcspTraceWarning(("\n %s %d  ProcessNumberOfEntries:%lu\n", __func__, __LINE__, i));
+    fprintf(stderr," %s %d  ProcessNumberOfEntries:%lu\n", __func__, __LINE__, i);
+    CcspTraceWarning((" %s %d  ProcessNumberOfEntries:%lu\n", __func__, __LINE__, i));
     return i;
 }
 

--- a/source/PandMSsp/ssp_main.c
+++ b/source/PandMSsp/ssp_main.c
@@ -583,7 +583,7 @@ if(id != 0)
            {
                CcspTraceError(("Argument missing after -subsys\n"));
            }
-           CcspTraceWarning(("\nSubsystem is %s\n", g_Subsystem));
+           CcspTraceInfo(("Subsystem is %s\n", g_Subsystem));
         }
         else if ( strcmp(argv[idx], "-c" ) == 0 )
         {

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -482,7 +482,7 @@ static unsigned long long GetAvailableSpace_tmp()
 
 static void UpdateSettingsFile( char param[64], char value[10] )
 {
-    CcspTraceInfo(("\nUpdateSettingsFile\n"));
+    CcspTraceInfo(("UpdateSettingsFile\n"));
     errno_t          rc                  = -1;
 
     FILE* fp = fopen( "/tmp/.hwselftest_settings", "r");
@@ -22934,7 +22934,7 @@ HwHealthTestPTREnable_SetParamBoolValue
                    ERR_CHK(rc);
                    return FALSE;
                 }
-                CcspTraceInfo(("\nExecuting command: %s\n", cmd));
+                CcspTraceInfo(("Executing command: %s\n", cmd));
                 v_secure_system("/usr/bin/hwselftest_cronjobscheduler.sh true &");
             }
             else
@@ -23090,12 +23090,12 @@ HwHealthTestPTRFrequency_SetParamUlongValue
             //Read the PTR enable param
             if (IsBoolSame(hInsContext, "enable", true, HwHealthTestPTREnable_GetParamBoolValue))
             {
-                CcspTraceInfo(("\n\nExecuting the command: /usr/bin/hwselftest_cronjobscheduler.sh true frequencyUpdate"));
+                CcspTraceInfo(("Executing the command: /usr/bin/hwselftest_cronjobscheduler.sh true frequencyUpdate\n"));
                 v_secure_system("/usr/bin/hwselftest_cronjobscheduler.sh true frequencyUpdate");
             }
             else
             {
-                CcspTraceInfo(("\n\nExecuting the command: /usr/bin/hwselftest_cronjobscheduler.sh false"));
+                CcspTraceInfo(("Executing the command: /usr/bin/hwselftest_cronjobscheduler.sh false\n"));
                 v_secure_system("/usr/bin/hwselftest_cronjobscheduler.sh false" );
             }
             return TRUE;


### PR DESCRIPTION
Reason for change: Removed the repetitive logs from PAM
Test Procedure: not applicable
Risks: Low
Priority: P1