### PR TITLE
RDKB-65854 : wifi boot time value is high

### DIFF
--- a/source/PandMSsp/ssp_main.c
+++ b/source/PandMSsp/ssp_main.c
@@ -702,7 +702,9 @@ if(id != 0)
     {
         if (!strncmp(value, "true", 4))
         {
-            v_secure_system("systemctl start systemd-cognitive_wifimotion.service");
+            /* Start WFM in background to avoid blocking PandM init.
+             * WFM has After=onewifi.service and will start once onewifi is active.*/
+            v_secure_system("systemctl start systemd-cognitive_wifimotion.service &");
         }
     }
 #endif

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -14502,7 +14502,9 @@ CognitiveMotionDetection_SetParamBoolValue
 
         if (bValue == TRUE)
         {
-            v_secure_system("systemctl start systemd-cognitive_wifimotion.service");
+            /* Start WFM in background to avoid blocking PandM init.
+             * WFM has After=onewifi.service and will start once onewifi is active.*/
+            v_secure_system("systemctl start systemd-cognitive_wifimotion.service &");
         }
         else
         {


### PR DESCRIPTION
Reason for change: [Regression]Boot time value is high for WiFI, LnF SSID, Webpa and WAN
   Problem is introduced by RDKB-65017 where wifimotion systemd dependency on onewifi
   but CcspPandMSsp launch wifimotion and onewifi is also depends on CcspPandMSsp which
   end up dependency loop.

Test Procedure: Build and verify /rdklogs/logs/BootTime.log
Risks: Low
Priority: P0

Signed-off-by: Santhosh_GujulvaJagadeesh@comcast.com