### PR TITLE
XB10-2798 : Modified subnetmask in Initial setup page not persistent 

### DIFF
--- a/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c
@@ -2300,7 +2300,7 @@ LanMngm_Validate
     lanSubnetMask = htonl(pLanMngm->LanSubnetMask.Value);
 
     /* Convert to network byte order and check subnetmask */
-#if defined(_BCI_FEATURE_REQ)
+#if defined(_BCI_FEATURE_REQ) || defined(_ONESTACK_PRODUCT_REQ_)
      if(lanSubnetMask != 0xFF000000 &&  //8
        lanSubnetMask != 0xFF800000 &&  //9
        lanSubnetMask != 0xFFC00000 &&  //10


### PR DESCRIPTION
Reason for change : Modified subnet mask in Initial setup page is not persistent after the reboot
Test Procedure: Verify in xb10-cb Initial setup page
Risks: Medium
Low Priority:P1
Signed-off-by: Rahul Sharma <rahul.sharma4@sky.uk>