### PR TITLE
RDKBACCL-1663:[TDK][AUTO][BPI][DML]Value of Device.DeviceInfo.SoftwareVersion is not complaint with the spec

### DIFF
--- a/config-arm/TR181-USGv2.XML
+++ b/config-arm/TR181-USGv2.XML
@@ -492,7 +492,7 @@
 
           <name>X_CISCO_COM_FirmwareName</name>
 
-          <type>string(64)</type>
+          <type>string(96)</type>
 
           <syntax>string</syntax>
 
@@ -502,7 +502,7 @@
 
           <name>X_RDK_FirmwareName</name>
 
-          <type>string(64)</type>
+          <type>string(96)</type>
 
           <syntax>string</syntax>
 
@@ -919,7 +919,7 @@
 
           <name>SoftwareVersion</name>
 
-          <type>string(64)</type>
+          <type>string(96)</type>
 
           <syntax>string</syntax>
 

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -1015,8 +1015,8 @@ DeviceInfo_GetParamStringValue
         (strcmp(ParamName, "X_CISCO_COM_FirmwareName") == 0) ||
         (strcmp(ParamName, "X_RDK_FirmwareName") == 0))
     {
-        if (*pulSize <= 64) {
-            *pulSize = 64 + 1;
+        if (*pulSize <= 96) {
+            *pulSize = 96 + 1;
             return 1;
         }
 


### PR DESCRIPTION
Reason for change: Increased SoftwareVersion/FirmwareName string size from 64 to 96 to accommodate release build image names that exceeded the TR-181 spec limit. 
Test Procedure: Build should success and functionality should work 
Risks: Low