### PR TITLE
RDKB-65995 preserve system logs during when wan link down

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_common_util.c
+++ b/source-arm/TR-181/board_sbapi/cosa_common_util.c
@@ -100,6 +100,7 @@ void ValidUlaHandleEventAsync(void);
 #endif
 
 volatile bool gWanStatus = false ; // false : stopped/starting, true : started
+
 #if defined(FEATURE_MAPT) || defined(FEATURE_SUPPORT_MAPT_NAT46)
 volatile int gMaptTotalPorts = 0 ;
 volatile bool gMaptEnabled = false ; // false : disabled, true : enabled
@@ -992,6 +993,13 @@ EvtDispterEventListen(void)
                 }
                 else if (!strncmp(value_str, "stopped", 7)) 
                 {
+		    if (gWanStatus) // guard against multiple stopped sysevent
+		    {
+                        // backup logs and preserve as wan went down
+		        CcspTraceInfo(("[%s][%d] sysevent wan-status stopped. Calling Backup logs\n", __FUNCTION__, __LINE__));
+		        system("/rdklogger/backupLogs.sh false \"\" wan-stopped \"\" &");
+		    }
+
                     gWanStatus = false;
                     ret = EVENT_WAN_STOPPED;
                 }


### PR DESCRIPTION
Reason for change: preserve system logs when wan link down for root cause analysis and further debugging.

Test Procedure:
    1. Verify that the device is operating normally with WAN connectivity established.
    2. Trigger a WAN link down event by disconnecting the WAN connection or simulating a WAN failure condition.
    3. Verify that the tgz file is created successfully and stored in the /nvram2/preserveLogs location.

Risks: Low

Priority: P1

Signed-off-by: Abdul_Shukur@comcast.com