### PR TITLE
        RDKBDEV-3351:Fix for EDNS package size incorrect, add RFC par…

### DIFF
--- a/config-arm/TR181-USGv2.XML
+++ b/config-arm/TR181-USGv2.XML
@@ -1891,10 +1891,8 @@
                         <functions>
                             <func_GetParamBoolValue>Feature_GetParamBoolValue</func_GetParamBoolValue>
                             <func_SetParamBoolValue>Feature_SetParamBoolValue</func_SetParamBoolValue>
-<?ifdef BCI?>
-                                <func_GetParamIntValue>Feature_GetParamIntValue</func_GetParamIntValue>
+                            <func_GetParamIntValue>Feature_GetParamIntValue</func_GetParamIntValue>
                         	<func_SetParamIntValue>Feature_SetParamIntValue</func_SetParamIntValue>
-<?endif?>
                             <func_GetParamStringValue>Feature_GetParamStringValue</func_GetParamStringValue>
                             <func_SetParamStringValue>Feature_SetParamStringValue</func_SetParamStringValue>
                         </functions>
@@ -1939,6 +1937,12 @@
                                 <writable>true</writable>
                             </parameter>
 <?endif?>
+                                <parameter>
+                                    <name>EDNSPacketSize</name>
+                                    <type>int</type>
+                                    <syntax>int</syntax>
+                                    <writable>true</writable>
+                                </parameter>
                             <parameter>
                                 <name>Xupnp</name>
                                 <type>boolean</type>

--- a/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_deviceinfo_dml.c
@@ -9481,6 +9481,17 @@ Feature_GetParamIntValue
              return TRUE;
          }
     }
+    if (strcmp(ParamName, "EDNSPacketSize") == 0)
+    {
+         /* collect value */
+         char buf[10];
+         syscfg_get( NULL, "edns_packet_size", buf, sizeof(buf));
+         if( buf [0] != '\0' )
+         {
+             *pint= ( atoi(buf) );
+             return TRUE;
+         }
+    }
     return FALSE;
 }
 /**********************************************************************
@@ -10948,6 +10959,21 @@ Feature_SetParamIntValue
                CcspTraceInfo(("syscfg_set low_queue_reboot_threshold failed\n"));
         }
 	return TRUE;
+    }
+    if (strcmp(ParamName, "EDNSPacketSize") == 0)
+    {
+        CcspTraceInfo(("Set EDNSPacketSize \n"));
+        char buf[8]={0};
+        snprintf(buf, sizeof(buf), "%d", bValue);
+
+        if (syscfg_set_commit(NULL, "edns_packet_size", buf) != 0)
+        {
+               CcspTraceInfo(("syscfg_set edns_packet_size failed\n"));
+        }
+        else
+        {
+            v_secure_system("sysevent set dhcp_server-restart");
+        }
     }
     return FALSE;
 }


### PR DESCRIPTION
…ameter for the packet size. CVE-2023-28450

        Reason for change:
        Add an RFC option to control the EDNS packet size.
        Test Procedure:
        1. Capture packages on lan client
        2. Send query with edns from lan client
        3. Check the UDP payload size in the Additional records in DNS response package, which should be 1232 instead of 4096
        4. set Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.EDNSPacketSize to 1800
        5. Send query with edns from lan client
        6. Check the UDP payload size in the Additional records in DNS response package, which should be 1800
       Risks: Low

        Signed-off-by: Owen Lu <owen_lu@sercomm.com>