### PR TITLE
SHARMAN-4090 LAN SSH not working in 6.3 SDK

### DIFF
--- a/arch/intel_usg/boards/arm_shared/scripts/partners_defaults.json
+++ b/arch/intel_usg/boards/arm_shared/scripts/partners_defaults.json
@@ -134,7 +134,8 @@
             "Device.X_RDK_Features.GatewayFailover.Enable" : "true",
             "Device.X_RDK_Features.UseCEDMPasswordForGUI" : "true",
             "Device.X_RDK_Features.VlanDiscovery.Enable" : "false",
-            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true"
+            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true",
+            "Device.X_RDK_Features.LanSshNewPortSupport.Enable" : "false"
       }
 },
 
@@ -231,7 +232,8 @@
             "Device.X_RDK_Features.GatewayFailover.Enable" : "true",
             "Device.X_RDK_Features.UseCEDMPasswordForGUI" : "true",
             "Device.X_RDK_Features.VlanDiscovery.Enable" : "false",
-            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true"
+            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true",
+            "Device.X_RDK_Features.LanSshNewPortSupport.Enable" : "false"
       }
 },
 
@@ -339,7 +341,8 @@
             "Device.X_RDK_Features.GatewayFailover.Enable" : "false",
             "Device.X_RDK_Features.UseCEDMPasswordForGUI" : "false",
             "Device.X_RDK_Features.VlanDiscovery.Enable" : "false",
-            "Device.X_RDK_Features.HotSpotSupport.Enable" : "false"
+            "Device.X_RDK_Features.HotSpotSupport.Enable" : "false",
+            "Device.X_RDK_Features.LanSshNewPortSupport.Enable" : "true"
       }
    },
 
@@ -503,7 +506,8 @@
             "Device.X_RDK_Features.GatewayFailover.Enable" : "false",
             "Device.X_RDK_Features.UseCEDMPasswordForGUI" : "false",
             "Device.X_RDK_Features.VlanDiscovery.Enable" : "true",
-            "Device.X_RDK_Features.HotSpotSupport.Enable" : "false"
+            "Device.X_RDK_Features.HotSpotSupport.Enable" : "false",
+            "Device.X_RDK_Features.LanSshNewPortSupport.Enable" : "true"
       }
    },
 
@@ -624,7 +628,8 @@
             "Device.X_RDK_Features.GatewayFailover.Enable" : "true",
             "Device.X_RDK_Features.UseCEDMPasswordForGUI" : "true",
             "Device.X_RDK_Features.VlanDiscovery.Enable" : "false",
-            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true"
+            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true",
+            "Device.X_RDK_Features.LanSshNewPortSupport.Enable" : "false"
       }
    },
 
@@ -746,7 +751,8 @@
             "Device.X_RDK_Features.GatewayFailover.Enable" : "true",
             "Device.X_RDK_Features.UseCEDMPasswordForGUI" : "true",
             "Device.X_RDK_Features.VlanDiscovery.Enable" : "false",
-            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true"
+            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true",
+            "Device.X_RDK_Features.LanSshNewPortSupport.Enable" : "false"
       }
    },
 
@@ -874,7 +880,8 @@
             "Device.X_RDK_Features.GatewayFailover.Enable" : "true",
             "Device.X_RDK_Features.UseCEDMPasswordForGUI" : "true",
             "Device.X_RDK_Features.VlanDiscovery.Enable" : "false",
-            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true"
+            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true",
+            "Device.X_RDK_Features.LanSshNewPortSupport.Enable" : "false"
       }
    },
 
@@ -977,7 +984,8 @@
             "Device.X_RDK_Features.GatewayFailover.Enable" : "true",
             "Device.X_RDK_Features.UseCEDMPasswordForGUI" : "true",
             "Device.X_RDK_Features.VlanDiscovery.Enable" : "false",
-            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true"
+            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true",
+            "Device.X_RDK_Features.LanSshNewPortSupport.Enable" : "false"
       }
    },
 "axb3retail" : {
@@ -1073,7 +1081,8 @@
             "Device.X_RDK_Features.GatewayFailover.Enable" : "true",
             "Device.X_RDK_Features.UseCEDMPasswordForGUI" : "true",
             "Device.X_RDK_Features.VlanDiscovery.Enable" : "false",
-            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true"
+            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true",
+            "Device.X_RDK_Features.LanSshNewPortSupport.Enable" : "false"
       }
   },
    "unknown" : {
@@ -1169,7 +1178,8 @@
             "Device.X_RDK_Features.GatewayFailover.Enable" : "true",
             "Device.X_RDK_Features.UseCEDMPasswordForGUI" : "true",
             "Device.X_RDK_Features.VlanDiscovery.Enable" : "false",
-            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true"
+            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true",
+            "Device.X_RDK_Features.LanSshNewPortSupport.Enable" : "false"
       }
    },
 
@@ -1270,7 +1280,8 @@
             "Device.X_RDK_Features.GatewayFailover.Enable" : "true",
             "Device.X_RDK_Features.UseCEDMPasswordForGUI" : "true",
             "Device.X_RDK_Features.VlanDiscovery.Enable" : "false",
-            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true"
+            "Device.X_RDK_Features.HotSpotSupport.Enable" : "true",
+            "Device.X_RDK_Features.LanSshNewPortSupport.Enable" : "false"
       }
    }
 


### PR DESCRIPTION
Reason for change: Creating a firewall rule to block SSH using WAN IP from LAN client

Test Procedure: NA

Risks: LOW

Priority: P1