### PR TITLE
RDKCOM-5621: RDKBDEV-3473 RDKBACCL-1569 [TDK][AUTO][BPI][DML]Value of Device.DNS.Client.Server.<i>.Status shows empty

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_dns_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_dns_apis.c
@@ -1139,6 +1139,7 @@ CosaDmlDnsClientGetServers
                             pServer[i].Order          = 1 + i;
                             pServer[i].InstanceNumber = 1 + i;
                             pServer[i].bEnabled       = TRUE;
+                            pServer[i].Status         = COSA_DML_DNS_STATUS_Enabled;
                             pServer[i].Type           = COSA_DML_DNS_ADDR_SRC_DHCPV4;
                             i++;
                             break;
@@ -1148,6 +1149,7 @@ CosaDmlDnsClientGetServers
                             pServer[i].Order          = 1 + i;
                             pServer[i].InstanceNumber = 1 + i;
                             pServer[i].bEnabled       = TRUE;
+                            pServer[i].Status         = COSA_DML_DNS_STATUS_Enabled;
                             pServer[i].Type           = COSA_DML_DNS_ADDR_SRC_DHCPV6;
                             i++;
                             break;


### PR DESCRIPTION
Reason for change:Device.DNS.Client.Server.{i}.Status return empty because CosaDmlDnsClientGetServers never set the Status field, setted it to Enabled for the active DHCP-learned servers. 
Test Procedure: Build should pass, status should be updated for Device.DNS.Client.Server.{i}.Status 
Risks:Low
Priority:P0