### PR TITLE
XB10-2917:Handle Partner Defaults Migration During OneStack Factory Reset

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c
@@ -2586,9 +2586,12 @@ CosaDmlDcSetFactoryReset
 		}
 
         char partnerId[20];
+        memset(partnerId,0,sizeof(partnerId));
+
+#ifndef _ONESTACK_PRODUCT_REQ_
+        // On OneStack, skip setTempPartnerId during FR: get_PartnerID() does not unlink
+        // /nvram/.partner_ID, so the file would wrongly persist after factory reset.
         int retVal = 0 ;
-        
-	memset(partnerId,0,sizeof(partnerId));
         retVal = syscfg_get(NULL, "PartnerID", partnerId, sizeof(partnerId)) ;
 
         if ( !retVal  && (access(PARTNERID_FILE, F_OK) != 0))
@@ -2596,6 +2599,7 @@ CosaDmlDcSetFactoryReset
             CcspTraceInfo(("Setting %s as partner ID\n", partnerId));
             setTempPartnerId( partnerId );
         } 
+#endif
 
 #ifdef _MACSEC_SUPPORT_
                 //TCXB7-1453


### PR DESCRIPTION
XB10-2917:Handle Partner Defaults Migration During OneStack Factory Reset

Reason for change:
Skip setTempPartnerId during factory reset on OneStack to prevent stale /nvram/.partner_ID values from being retained. Update apply_system_defaults to trigger partner defaults migration when devicemode is empty on OneStack

Test Procedure: Migration of Fireware should work properly

Risks: Low

Priority : P1

Signed-off-by: Goutam_Damodaran@comcast.com