### PR TITLE
RDKBDEV-3470,RDKBACCL-1945 : Device Not coming Online for Configurable WAN Etherne…

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
@@ -445,8 +445,17 @@ CosaDmlIpInit
            rc = strcpy_s((char *)g_ipif_names[i],sizeof(g_ipif_names[i]), G_USG_IF_NAME(i));
 #if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)
           char out_value[64] = {0};
-          if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
-                 rc = strcpy_s((char *)g_ipif_names[i], sizeof(g_ipif_names[i]), out_value);
+		  fp = fopen("/nvram/wan_name.txt", "r");
+          if (fp != NULL)
+          {
+			  fprintf(fp, "%s", out_value);
+			  rc = strcpy_s((char *)g_ipif_names[i], sizeof(g_ipif_names[i]), out_value);
+		  }
+	      else
+		  {
+			  if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
+				  rc = strcpy_s((char *)g_ipif_names[i], sizeof(g_ipif_names[i]), out_value);  
+		  }	       
 #endif
         }
         else

--- a/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
@@ -445,11 +445,13 @@ CosaDmlIpInit
            rc = strcpy_s((char *)g_ipif_names[i],sizeof(g_ipif_names[i]), G_USG_IF_NAME(i));
 #if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)
           char out_value[64] = {0};
+		   FILE *fp = NULL;
 		  fp = fopen("/nvram/wan_name.txt", "r");
           if (fp != NULL)
           {
 			  fprintf(fp, "%s", out_value);
 			  rc = strcpy_s((char *)g_ipif_names[i], sizeof(g_ipif_names[i]), out_value);
+			  fclose(fp);
 		  }
 	      else
 		  {

--- a/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
@@ -446,11 +446,11 @@ CosaDmlIpInit
 #if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)
           char out_value[64] = {0};
           if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
-              rc = strcpy_s((char *)g_ipif_names[i], sizeof(g_ipif_names[i]), out_value);
+                 rc = strcpy_s((char *)g_ipif_names[i], sizeof(g_ipif_names[i]), out_value);
 #endif
         }
         else
-          rc = strcpy_s((char *)g_ipif_names[i],sizeof(g_ipif_names[i]), G_USG_IF_NAME(i));        
+             rc = strcpy_s((char *)g_ipif_names[i],sizeof(g_ipif_names[i]), G_USG_IF_NAME(i));        
         ERR_CHK(rc);
         if ((gDmsbIpIfLoopbackInstNum == 0) && (strcmp(G_USG_IF_NAME(i), "lo") == 0))
         {

--- a/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
@@ -444,9 +444,9 @@ CosaDmlIpInit
         {
            rc = strcpy_s((char *)g_ipif_names[i],sizeof(g_ipif_names[i]), G_USG_IF_NAME(i));
 #if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)
-          char out_value[20] = {0};
+          char out_value[64] = {0};
           if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
-              strcpy_s((char *)g_ipif_names[i], sizeof(g_ipif_names[i]), out_value);
+              rc = strcpy_s((char *)g_ipif_names[i], sizeof(g_ipif_names[i]), out_value);
 #endif
         }
         else

--- a/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
@@ -440,7 +440,17 @@ CosaDmlIpInit
 	   g_usg_if_cfg[i].LinkType = ( TRUE == IsThisCurrentPartnerID("sky-") ) ? COSA_DML_LINK_TYPE_VlanLink : COSA_DML_LINK_TYPE_EthLink;   
 	}
 #endif
-        rc = strcpy_s((char *)g_ipif_names[i],sizeof(g_ipif_names[i]), G_USG_IF_NAME(i));
+        if (i == 0)
+        {
+           rc = strcpy_s((char *)g_ipif_names[i],sizeof(g_ipif_names[i]), G_USG_IF_NAME(i));
+#if defined(FEATURE_RDKB_CONFIGURABLE_WAN_INTERFACE)
+          char out_value[20] = {0};
+          if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
+              strcpy_s((char *)g_ipif_names[i], sizeof(g_ipif_names[i]), out_value);
+#endif
+        }
+        else
+          rc = strcpy_s((char *)g_ipif_names[i],sizeof(g_ipif_names[i]), G_USG_IF_NAME(i));        
         ERR_CHK(rc);
         if ((gDmsbIpIfLoopbackInstNum == 0) && (strcmp(G_USG_IF_NAME(i), "lo") == 0))
         {


### PR DESCRIPTION
…t Based approach
Reason for change : In Ethernet based code flow , the Device.IP.Interface DM's are not updating with the configurred wan name when Configurable wan is enabled
Test Procedure : Customise the wan name and check the DM's , it is affecting the components like Tr069
Risks : Low
Priority : P1