### PR TITLE
RDKCOM-5622: RDKBDEV-3474 RDKBACCL-1672: [TDK] [AUTO][BPI][DML]Adding row instances to the writable table object Device.Routing.Router.1.IPv6Forwarding.<i>. succeeds, but rows are not added

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_routing_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_routing_apis.c
@@ -3423,6 +3423,29 @@ Route6_GetInfoByInsNum(int insNum, int *index)
     return NULL;
 }
 
+static RouteInfo6_t *
+Route6_GetInfoByRoute(const char *prefix, const char *gw, const char *dev, int *index)
+{
+    int i;
+
+    if (!prefix || !dev)
+        return NULL;
+
+    for (i = 0; i < g_numRtInfo6; i++)
+    {
+        if ((strcmp(g_routeInfos6[i].prefix, prefix) == 0) &&
+            (strcmp(g_routeInfos6[i].gateway, gw ? gw : "") == 0) &&
+            (strcmp(g_routeInfos6[i].interface, dev) == 0))
+        {
+            if (index)
+                *index = i;
+            return &g_routeInfos6[i];
+        }
+    }
+
+    return NULL;
+}
+
 static int
 Route6_SaveParams(const RouteAlias6_t *alias6)
 {
@@ -4893,9 +4916,13 @@ CosaDmlRoutingDelV6Entry
     if (!pEntry)
         return ANSC_STATUS_FAILURE;
 
-    if ((info6 = Route6_GetInfoByInsNum(pEntry->InstanceNumber, &index)) == NULL) 
+    if ((info6 = Route6_GetInfoByInsNum(pEntry->InstanceNumber, &index)) == NULL)
     {
-		CcspTraceWarning(("%s: instance not exist\n", __FUNCTION__));
+	info6 = Route6_GetInfoByRoute(pEntry->DestIPPrefix, pEntry->NextHop, pEntry->Interface, &index);
+    }
+    if (info6 == NULL)
+    {
+	CcspTraceWarning(("%s: instance not exist\n", __FUNCTION__));
         return ANSC_STATUS_FAILURE;
     }
     alias6 = &info6->alias6;

--- a/source/TR-181/middle_layer_src/cosa_routing_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_routing_dml.c
@@ -73,6 +73,7 @@
 #include "cosa_deviceinfo_apis.h"
 #include "ansc_string_util.h"
 #include "safec_lib_common.h"
+#include "cosa_apis_busutil.h"
 
 #define REFRESH_INTERVAL 120
 #define TIME_NO_NEGATIVE(x) ((long)(x) < 0 ? 0 : (x))
@@ -3277,6 +3278,15 @@ IPv6Forwarding_AddEntry
       return NULL;
     }
 
+    pEntry->Status           = COSA_DML_ROUTING_STATUS_Enabled;
+    pEntry->Origin           = COSA_DML_ROUTING_IPV6_ORIGIN_Static;
+    pEntry->ForwardingPolicy = -1;
+    rc = sprintf_s(pEntry->ExpirationTime, sizeof(pEntry->ExpirationTime), "9999-12-31T23:59:59Z");
+    if(rc < EOK)
+    {
+      ERR_CHK(rc);
+    }
+
     /* Update the middle layer data */
     if ( TRUE )
     {
@@ -3518,6 +3528,10 @@ IPv6Forwarding_Synchronize
             continue;
         }
         
+        if ( pCxtLink->bNew ){
+            continue;
+        }
+
         /* We  need delete this one no matter whether it's not static*/
         //if ( pEntry->Origin != COSA_DML_ROUTING_IPV6_ORIGIN_Static ){
             AnscSListPopEntryByLink(&pRouter->IPv6ForwardList, pSListEntry2);
@@ -4172,12 +4186,22 @@ IPv6Forwarding_SetParamStringValue
     if((ind == 0) && (rc == EOK))
     {
 		char wrapped_inputparam[64]={0};
+		char  ifname[64]      = {0};
+		ULONG ifnameLen       = sizeof(ifname);
+		char  nameParam[256]  = {0};
+
 		ret=isValidInput(pString,wrapped_inputparam, AnscSizeOfString(pString), sizeof( wrapped_inputparam ));
         if(ANSC_STATUS_SUCCESS != ret)
             return FALSE;
 
-        /* save update to backup */
-        rc = STRCPY_S_NOCLOBBER(pRouterForward->Interface, sizeof(pRouterForward->Interface), wrapped_inputparam);
+        if (strstr(pString, "Device.IP.Interface.") == pString)
+        {
+            snprintf(nameParam, sizeof(nameParam), "%sName", pString);
+            if ((0 == CosaGetParamValueString(nameParam, ifname, &ifnameLen)) && (ifname[0] != '\0'))
+                pString = ifname;
+        }
+        rc = STRCPY_S_NOCLOBBER(pRouterForward->Interface, sizeof(pRouterForward->Interface), pString);
+
         if(rc != EOK)
         {
             ERR_CHK(rc);


### PR DESCRIPTION
Reason for change:
Fix IPv6Forwarding add, delete and new row defaults

Interface set: Not able to set the interface name, DM updates Device.IP.Interface.{i}. to its ifname before storing, and stop storing the quote-wrapped value. The backend uses the low-level ifname as the route 'dev', storing the object path which is quoted  produced an invalid dev and route add failed.

Delete: add Route6_GetInfoByRoute and use it as a fallback in CosaDmlRoutingDelV6Entry when the instance-number lookup misses. The DM InstanceNumber is not kept in sync with the backend insNum, so deltable was removing the DM row but not the kernel route, which then got re-learned. Match by prefix/gateway/interface in Route6_GetInfoByRoute the route is actually removed.

Synchronize: skip bNew rows so a new added table entry is not wiped before commit (was causing CCSP 9005 on the new instance).

AddEntry: initialise Status=Enabled, Origin=Static, ForwardingPolicy=-1 and ExpirationTime for a new row, these are read-only  fields that cannot set in runtime, so without defaults the row showed blank values, added defaults

Test Procedure: As mentioned in respective ticket RDKBACCL-1672
Risks: Low
Priority: P2