### PR TITLE
RDKB-66032 : Add auto cherry-pick and gatekeeper workflow callers

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -3,28 +3,13 @@ name: Automated Cherry-Pick Engine
 on:
   pull_request:
     types: [labeled, closed]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'Already-merged PR number to cherry-pick'
-        required: true
-        type: string
-      target_branch:
-        description: 'Target branch to cherry-pick to (e.g. support/stable2)'
-        required: true
-        type: string
 
 jobs:
   cherry-pick:
-    if: |
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.merged == true &&
-       contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')) ||
-      github.event_name == 'workflow_dispatch'
+    if: github.event.pull_request.merged == true && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')
     uses: rdkcentral/build_tools_workflows/.github/workflows/cherry-pick.yml@develop
     with:
-      raw_labels: ${{ github.event_name == 'workflow_dispatch' && format('[{{"name":"cherry-pick to {0}"}}]', inputs.target_branch) || toJSON(github.event.pull_request.labels) }}
-      trigger_label: ${{ github.event_name == 'workflow_dispatch' && format('cherry-pick to {0}', inputs.target_branch) || github.event.label.name }}
-      pr_number_override: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || '' }}
+      raw_labels: ${{ toJSON(github.event.pull_request.labels) }}
+      trigger_label: ${{ github.event.label.name }}
     secrets:
       CROSS_REPO_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -3,13 +3,22 @@ name: Automated Cherry-Pick Engine
 on:
   pull_request:
     types: [labeled, closed]
+  issues:
+    types: [labeled]
 
 jobs:
   cherry-pick:
-    if: github.event.pull_request.merged == true && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')
+    if: |
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')) ||
+      (github.event_name == 'issues' &&
+       github.event.issue.pull_request.url != '' &&
+       contains(toJSON(github.event.issue.labels.*.name), 'cherry-pick to '))
     uses: rdkcentral/build_tools_workflows/.github/workflows/cherry-pick.yml@develop
     with:
-      raw_labels: ${{ toJSON(github.event.pull_request.labels) }}
+      raw_labels: ${{ github.event_name == 'issues' && toJSON(github.event.issue.labels) || toJSON(github.event.pull_request.labels) }}
       trigger_label: ${{ github.event.label.name }}
+      pr_number_override: ${{ github.event_name == 'issues' && github.event.issue.number || '' }}
     secrets:
       CROSS_REPO_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -3,24 +3,13 @@ name: Automated Cherry-Pick Engine
 on:
   pull_request:
     types: [labeled, closed]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'Already-merged PR number to cherry-pick'
-        required: true
-        type: string
-      target_branch:
-        description: 'Target branch (e.g. support/stable2)'
-        required: true
-        type: string
 
 jobs:
   cherry-pick:
-    if: (github.event.pull_request.merged == true && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')) || github.event_name == 'workflow_dispatch'
+    if: github.event.pull_request.merged == true && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')
     uses: rdkcentral/build_tools_workflows/.github/workflows/cherry-pick.yml@develop
     with:
-      raw_labels: ${{ github.event_name == 'workflow_dispatch' && format('[{{"name":"cherry-pick to {0}"}}]', inputs.target_branch) || toJSON(github.event.pull_request.labels) }}
-      trigger_label: ${{ github.event_name == 'workflow_dispatch' && format('cherry-pick to {0}', inputs.target_branch) || github.event.label.name }}
-      pr_number_override: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || '' }}
+      raw_labels: ${{ toJSON(github.event.pull_request.labels) }}
+      trigger_label: ${{ github.event.label.name }}
     secrets:
       CROSS_REPO_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -1,0 +1,15 @@
+name: Automated Cherry-Pick Engine
+
+on:
+  pull_request:
+    types: [labeled, closed]
+
+jobs:
+  cherry-pick:
+    if: github.event.pull_request.merged == true && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')
+    uses: rdkcentral/build_tools_workflows/.github/workflows/cherry-pick.yml@develop
+    with:
+      raw_labels: ${{ toJSON(github.event.pull_request.labels) }}
+      trigger_label: ${{ github.event.label.name }}
+    secrets:
+      CROSS_REPO_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -3,13 +3,28 @@ name: Automated Cherry-Pick Engine
 on:
   pull_request:
     types: [labeled, closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Already-merged PR number to cherry-pick'
+        required: true
+        type: string
+      target_branch:
+        description: 'Target branch (e.g. support/stable2)'
+        required: true
+        type: string
 
 jobs:
   cherry-pick:
-    if: github.event.pull_request.merged == true && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')
+    if: |
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')) ||
+      github.event_name == 'workflow_dispatch'
     uses: rdkcentral/build_tools_workflows/.github/workflows/cherry-pick.yml@develop
     with:
-      raw_labels: ${{ toJSON(github.event.pull_request.labels) }}
-      trigger_label: ${{ github.event.label.name }}
+      raw_labels: ${{ github.event_name == 'workflow_dispatch' && format('[{{"name":"cherry-pick to {0}"}}]', inputs.target_branch) || toJSON(github.event.pull_request.labels) }}
+      trigger_label: ${{ github.event_name == 'workflow_dispatch' && format('cherry-pick to {0}', inputs.target_branch) || github.event.label.name }}
+      pr_number_override: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || '' }}
     secrets:
       CROSS_REPO_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -3,8 +3,16 @@ name: Automated Cherry-Pick Engine
 on:
   pull_request:
     types: [labeled, closed]
-  issues:
-    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Already-merged PR number to cherry-pick'
+        required: true
+        type: string
+      target_branch:
+        description: 'Target branch to cherry-pick to (e.g. support/stable2)'
+        required: true
+        type: string
 
 jobs:
   cherry-pick:
@@ -12,13 +20,11 @@ jobs:
       (github.event_name == 'pull_request' &&
        github.event.pull_request.merged == true &&
        contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')) ||
-      (github.event_name == 'issues' &&
-       github.event.issue.pull_request.url != '' &&
-       contains(toJSON(github.event.issue.labels.*.name), 'cherry-pick to '))
+      github.event_name == 'workflow_dispatch'
     uses: rdkcentral/build_tools_workflows/.github/workflows/cherry-pick.yml@develop
     with:
-      raw_labels: ${{ github.event_name == 'issues' && toJSON(github.event.issue.labels) || toJSON(github.event.pull_request.labels) }}
-      trigger_label: ${{ github.event.label.name }}
-      pr_number_override: ${{ github.event_name == 'issues' && github.event.issue.number || '' }}
+      raw_labels: ${{ github.event_name == 'workflow_dispatch' && format('[{{"name":"cherry-pick to {0}"}}]', inputs.target_branch) || toJSON(github.event.pull_request.labels) }}
+      trigger_label: ${{ github.event_name == 'workflow_dispatch' && format('cherry-pick to {0}', inputs.target_branch) || github.event.label.name }}
+      pr_number_override: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || '' }}
     secrets:
       CROSS_REPO_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -16,11 +16,7 @@ on:
 
 jobs:
   cherry-pick:
-    if: |
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.merged == true &&
-       contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')) ||
-      github.event_name == 'workflow_dispatch'
+    if: (github.event.pull_request.merged == true && contains(toJSON(github.event.pull_request.labels.*.name), 'cherry-pick to ')) || github.event_name == 'workflow_dispatch'
     uses: rdkcentral/build_tools_workflows/.github/workflows/cherry-pick.yml@develop
     with:
       raw_labels: ${{ github.event_name == 'workflow_dispatch' && format('[{{"name":"cherry-pick to {0}"}}]', inputs.target_branch) || toJSON(github.event.pull_request.labels) }}

--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -1,0 +1,23 @@
+name: Topic Gatekeeper
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - develop
+      - 'release/**'
+      - 'support/**'
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  run-shared-gatekeeper:
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request_review' &&
+       (github.event.pull_request.base.ref == 'develop' ||
+        startsWith(github.event.pull_request.base.ref, 'release/') ||
+        startsWith(github.event.pull_request.base.ref, 'support/')))
+    uses: rdkcentral/build_tools_workflows/.github/workflows/gatekeeper.yml@develop
+    secrets:
+      CROSS_REPO_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}


### PR DESCRIPTION
Adds two workflow callers that integrate with the shared engine in rdkcentral/build_tools_workflows (PR #70).

**`auto-backport.yml`** — triggers on PR merge when labeled `cherry-pick to <branch>`:
- Calls shared cherry-pick engine which auto-creates a backport PR to the target branch
- Handles conflicts, missing branches, and already-applied cases with PR comments
- Requires `CROSS_REPO_TOKEN` secret for cross-repo cascade (topic labels)

**`gatekeeper.yml`** — triggers on PR open/sync/review:
- develop: informational only, non-blocking
- release/support: strict — blocks merge if any companion PR is unapproved or missing cherry-pick
- Scoped to develop, release/**, support/** branches only

Reason for change: Enable automated backporting and cross-repo review enforcement
Test Procedure: Verified on bunnam988 fork — cherry-pick engine creates PRs, posts conflict/error comments; gatekeeper passes on develop
Risks: Low
Priority: P1