### PR TITLE
RDKBDEV-3479 : Validate FactoryReset input in SetParamStringValue

### DIFF
--- a/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_x_cisco_com_devicecontrol_dml.c
@@ -1385,6 +1385,86 @@ X_CISCO_COM_DeviceControl_SetParamUlongValue
     return FALSE;
 }
 
+/**********************************************************************
+
+    helper: IsValidFactoryResetString
+
+    description:
+
+        Validates a comma-separated FactoryReset token string against
+        the set of tokens recognised by CosaDmlDcSetFactoryReset.
+
+        Valid tokens: Router, Wifi, Firewall, VoIP, Docsis, Dect, MoCA
+        Valid tokens (when FEATURE_RDKB_CELLULAR_MANAGER is defined): Cellular
+        Dect and MoCA are accepted for compatibility with legacy internal
+        callers (e.g. CosaDmlDiPartnerIDChangeHandling) but are silently
+        ignored by CosaDmlDcSetFactoryReset in the backend.
+        At least one valid token must be present.
+
+    argument:   const char *pString
+                The value string to validate (must not be NULL).
+
+    return:     TRUE  if every token is valid and at least one is present.
+                FALSE if the string is empty, contains an unknown token,
+                      or contains only whitespace/delimiters.
+
+**********************************************************************/
+static BOOL
+IsValidFactoryResetString
+    (
+        const char *pString
+    )
+{
+    char   tmpBuf[256];
+    char  *tok  = NULL;
+    char  *sv   = NULL;
+    BOOL   valid = FALSE;
+    int    i;
+    static const char * const validTokens[] =
+    {
+        "Router",
+        "Wifi",
+        "Firewall",
+        "VoIP",
+        "Docsis",
+        "Dect",
+        "MoCA",
+#ifdef FEATURE_RDKB_CELLULAR_MANAGER
+        "Cellular",
+#endif
+        NULL
+    };
+
+    if (pString == NULL || pString[0] == '\0')
+    {
+        CcspTraceError(("FactoryReset: empty or NULL value is not valid\n"));
+        return FALSE;
+    }
+
+    snprintf(tmpBuf, sizeof(tmpBuf), "%s", pString);
+    tok = strtok_r(tmpBuf, ",", &sv);
+    while (tok)
+    {
+        for (i = 0; validTokens[i] != NULL; i++)
+        {
+            if (strcmp(tok, validTokens[i]) == 0)
+                break;
+        }
+        if (validTokens[i] != NULL)
+        {
+            valid = TRUE;
+        }
+        else
+        {
+            CcspTraceError(("FactoryReset: invalid token '%s'\n", tok));
+            return FALSE;
+        }
+        tok = strtok_r(NULL, ",", &sv);
+    }
+
+    return valid;
+}
+
 /**********************************************************************  
 
     caller:     owner of this object 
@@ -1453,6 +1533,9 @@ X_CISCO_COM_DeviceControl_SetParamStringValue
     ERR_CHK(rc);
     if((rc == EOK) && (!ind))
     {
+        if (!IsValidFactoryResetString(pString))
+            return FALSE;
+
         rc = STRCPY_S_NOCLOBBER((char *)pMyObject->FactoryReset, sizeof(pMyObject->FactoryReset), pString);
         if(rc != EOK)
         {


### PR DESCRIPTION
Reason for change: The `Device.DeviceInfo.X_CISCO_COM_DeviceControl.FactoryReset` data model accepted any string on SET. `X_CISCO_COM_DeviceControl_SetParamStringValue` stored the value without validating it, and the subsequent failure from `CosaDmlDcSetFactoryReset` was discarded by the CCSP framework — `DslhWmpdoMpaSetCommit` unconditionally resets `returnStatus` to `ANSC_STATUS_SUCCESS` after calling `SetCommit`. As a result `dmcli` reported success for invalid or empty input while no factory reset was performed.

This change validates the token string at set time so an invalid value is rejected before it is stored and the caller gets a proper failure.

A new static helper `IsValidFactoryResetString()` is added immediately before `X_CISCO_COM_DeviceControl_SetParamStringValue`. It uses a NULL-terminated `validTokens[]` list, so adding a token later is a one-line change. The list mirrors exactly the tokens recognised by `CosaDmlDcSetFactoryReset` in `source-arm/TR-181/board_sbapi/cosa_x_cisco_com_devicecontrol_apis.c`:

- `Router`, `Wifi`, `Firewall`, `VoIP`, `Docsis`
- `Cellular` (only when `FEATURE_RDKB_CELLULAR_MANAGER` is defined)
- `Dect`, `MoCA` — accepted for compatibility with legacy internal callers (`CosaDmlDiPartnerIDChangeHandling` sets `Router,Wifi,VoIP,Dect,MoCA`). These are silently ignored by `CosaDmlDcSetFactoryReset` in the backend, so the pre-existing behaviour is preserved.

Empty and NULL strings are also rejected. Any unrecognised token causes an immediate `return FALSE`.

Test Procedure:
Valid values are still accepted and continue to trigger the factory reset:

```
dmcli eRT setv Device.DeviceInfo.X_CISCO_COM_DeviceControl.FactoryReset string Router
dmcli eRT setv Device.DeviceInfo.X_CISCO_COM_DeviceControl.FactoryReset string Router,Wifi
dmcli eRT setv Device.DeviceInfo.X_CISCO_COM_DeviceControl.FactoryReset string VoIP,Docsis
dmcli eRT setv Device.DeviceInfo.X_CISCO_COM_DeviceControl.FactoryReset string Router,Wifi,VoIP,Dect,MoCA
```

Invalid values are now rejected instead of silently reporting success:

```
dmcli eRT setv Device.DeviceInfo.X_CISCO_COM_DeviceControl.FactoryReset string Bogus
dmcli eRT setv Device.DeviceInfo.X_CISCO_COM_DeviceControl.FactoryReset string Router,Bogus
dmcli eRT setv Device.DeviceInfo.X_CISCO_COM_DeviceControl.FactoryReset string ""
```

Expected: `dmcli` returns a failure (`CCSP_FAILURE`) and `CcspTraceError` logs the offending token; no factory reset is performed and the stored value is unchanged.

The helper's branch logic was additionally verified standalone under `gcc -Wall -Wextra` against the inputs `Router`, `Router,Wifi`, `VoIP,Docsis`, `""`, `Bogus`, `Router,Bogus` and `NULL`, plus `Router,Wifi,VoIP,Dect,MoCA`, `Dect`, `MoCA` and `Cellular`, both with and without `FEATURE_RDKB_CELLULAR_MANAGER`, with no warnings.

Risks: Low — the change is confined to the `FactoryReset` branch of a single setter. It only adds an input check ahead of the existing store; no behaviour changes for valid input, and no data model, API or interface changes. The only behavioural difference is that previously-accepted invalid input now correctly fails instead of being silently ignored. Any caller that relied on sending an invalid token and receiving success would now see a failure.

Priority: P2

---

This fix was previously carried downstream as a Yocto `.bbappend` patch on the `ccsp-p-and-m` recipe. Upstreaming here so the downstream patch can be dropped. Original change authored by Udhaya R G <urg@qti.qualcomm.com>.
