### PR TITLE
RDKBACCL-1906: Brlan0 mtu value is not updated after configuring

### DIFF
--- a/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
+++ b/source-arm/TR-181/board_sbapi/cosa_ip_apis.c
@@ -2424,6 +2424,14 @@ CosaDmlIpIfSetCfg
 {
     if ( pCfg->InstanceNumber >= COSA_USG_IF_NUM )
     {
+#ifdef BRLAN0_MTU_SUPPORT_FEATURE
+        if (strstr(pCfg->LinkName, "brlan0"))
+        {
+            char mtu_str[32] = {0};
+            snprintf(mtu_str, sizeof(mtu_str), "%lu", pCfg->MaxMTUSize);
+            CosaUtilSetBrlan0MTU(pCfg->LinkName, mtu_str);
+        }
+#endif
         return  CosaDmlIpIfMlanSetCfg(hContext, pCfg);
     }
     else

--- a/source/TR-181/middle_layer_src/cosa_apis_util.c
+++ b/source/TR-181/middle_layer_src/cosa_apis_util.c
@@ -96,6 +96,10 @@
 //$HL 4/30/2013
 #include "ccsp_psm_helper.h"
 
+#ifdef CORE_NET_LIB
+#include <libnet.h>
+#endif
+
 #if defined (FEATURE_RDKB_WAN_MANAGER)
 extern ANSC_HANDLE bus_handle;
 #define ETH_AGENT_COMPONENT_NAME                "eRT.com.cisco.spvtg.ccsp.ethagent"
@@ -1613,6 +1617,44 @@ _EXIT:
     close(sock);
     return ret;
 }
+
+#ifdef BRLAN0_MTU_SUPPORT_FEATURE
+void CosaUtilSetBrlan0MTU(char * if_name, char * mtu_size)
+{
+    char current_if_list[1024] = {0};
+    FILE *fp;
+    int ret;
+
+#ifdef CORE_NET_LIB
+    ret = interface_set_mtu(if_name, mtu_size);
+#endif
+    if (ret != 0)
+    {
+        AnscTraceFlow(("%s: Failed to set MTU on %s (ret=%d)\n", __FUNCTION__, if_name, ret));
+    }
+
+    fp = v_secure_popen("r","brctl show %s | sed '1d' | awk '{print $NF}' | tr '\n' ' ' ", if_name);
+    if ( fp != NULL )
+    {
+        if(fgets(current_if_list,sizeof(current_if_list)-1,fp) != NULL)
+	{
+            for (char *token = strtok(current_if_list, " "); token != NULL; token = strtok(NULL, " "))
+	    {
+                ret = interface_set_mtu(token, mtu_size);
+                if (ret != 0)
+		{
+                    AnscTraceFlow(("%s: Failed to set MTU on %s (ret=%d)\n", __FUNCTION__, token, ret));
+                }
+            }
+        }
+        ret = v_secure_pclose(fp);
+        if (ret != 0) 
+        {
+            AnscTraceFlow(("%s: Error in closing pipe! [%d]\n", __FUNCTION__, ret));
+        }
+    }
+}
+#endif
 
 #if defined( _HUB4_PRODUCT_REQ_ ) || defined( _SR300_PRODUCT_REQ_ ) || defined(_RDKB_GLOBAL_PRODUCT_REQ_)
 

--- a/source/TR-181/middle_layer_src/cosa_apis_util.h
+++ b/source/TR-181/middle_layer_src/cosa_apis_util.h
@@ -73,6 +73,7 @@
 #define  _COSA_APIS_UTIL_H
 
 #include "cosa_dml_api_common.h"
+#include "secure_wrapper.h"
 
 typedef struct StaticRoute
 {
@@ -269,6 +270,17 @@ int CosaUtilGetIfStats(char * ifname, PCOSA_DML_IF_STATS  pStats);
  *
  */
 ULONG CosaUtilIoctlXXX(char * if_name, char * method, void * input);
+
+/**
+ * @brief Execute MTU size set operation on a network interface.
+ *
+ * This function performs an ioctl operation on the specified network interface.
+ *
+ * @param[in] if_name - Pointer to the interface name.
+ * @param[in] mtu_size  - Pointer to the MTU size.
+ *
+ */
+void CosaUtilSetBrlan0MTU(char * if_name, char * mtu_size);
 
 /**
  * @brief Convert a netmask string to a number.

--- a/source/TR-181/middle_layer_src/cosa_ip_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_ip_dml.c
@@ -1219,6 +1219,13 @@ Interface2_GetParamUlongValue
             pIPInterface->Cfg.MaxMTUSize = CosaUtilIoctlXXX((char *)pIPInterface->Cfg.LinkName, "mtu", NULL);
         }
 #endif
+
+#ifdef BRLAN0_MTU_SUPPORT_FEATURE
+        if (strstr(pIPInterface->Cfg.LinkName, "brlan0"))
+        {
+            pIPInterface->Cfg.MaxMTUSize = CosaUtilIoctlXXX((char *)pIPInterface->Cfg.LinkName, "mtu", NULL);
+        }
+#endif
         /* collect value */
         *puLong = pIPInterface->Cfg.MaxMTUSize;
 


### PR DESCRIPTION
Reason for change:
Added customized MTU value feature for brlan0 interface. 
Test Procedure:
1) Verify SET and GET operations on MaxMTUSize of brlan0 DM are working or not. 
2) Value should be updated in brlan0 interface and it's associated interfaces as well. 
Risks: Low